### PR TITLE
feat: Introduce request level properties in ServiceContext middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,25 @@ For specifics, check the detailed features below.
 
 ### Logger
 We integrated `go.uber.org/zap`
+
 ### Dynamic request context
-You can inject custom properties into the service context via props. This object is of type `any` so you can pass anything into your context to make it accessible in your endpoints
+You can inject custom properties into the service context via props. This object is of type `any` so you can pass anything into your context to make it accessible in your endpoints.
+
+You could also access request level properties by making use of `RequestProps` in ServiceContext.
+
 ```go
 func (h *Handler) GetData(ctx echo.Context) error {
     sctx := context.GetServiceContext[any](ctx)
     log := sctx.ZapLogger
+	// props contain service level properties which are shared across all requests
+	props := sctx.Props.(map[string]interface{})
 
+	// requestProps contain request level properties which can be set and accessed from within the handler or middleware
+	sctx.RequestProps["country"] = "NL"
     ...
 }
 ```
+
 ### Endpoint router
 The router is providing a couple of preset endpoints for swagger, monitoring and health checks but custom endpoints can also be injected. The router wrapper in the example above can be used to register additional endpoints.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ For specifics, check the detailed features below.
 		Routes: func(e *echo.Echo, r *router.Router) error {
 			return configureRoutes(e, r, db)
 		},
+		// Properties which would be shared across all the requests in the service via ServiceContext
 		ContextProps: map[string]interface{}{
 			"my_property": "",
 		},

--- a/config.go
+++ b/config.go
@@ -27,9 +27,10 @@ type Config struct {
 	ExtraEnvs           env.Map
 	ValidationRegistrar func(v *router.Validator) error
 	Routes              func(e *echo.Echo, r *router.Router) error
-	ContextProps        any
-	Opts                Opts
-	Plugins             []Plugin
+	// ContextProps would be shared across all requests in the service
+	ContextProps any
+	Opts         Opts
+	Plugins      []Plugin
 }
 
 // Opts define configuration options for fastecho.

--- a/context/context.go
+++ b/context/context.go
@@ -25,7 +25,10 @@ type ServiceContext[T any] struct {
 	echo.Context
 	ZapLogger *zap.Logger
 	Tracer    *trace.Tracer
-	Props     T
+	// Props would be shared across all requests in the service
+	Props T
+	// RequestProps values are unique to each requests
+	RequestProps map[string]interface{}
 }
 
 // BindValidate binds the data to the given interface and validates the input given using validator/10.
@@ -57,8 +60,9 @@ func ServiceContextMiddleware[T any](logger *zap.Logger, tracer *trace.Tracer, p
 			spanId := spanCtx.SpanID().String()
 
 			sctx := &ServiceContext[T]{
-				Props:   props,
-				Context: ctx,
+				Props:        props,
+				RequestProps: map[string]interface{}{},
+				Context:      ctx,
 				ZapLogger: logger.With(
 					zap.String("trace_id", traceId),
 					zap.String("span_id", spanId),


### PR DESCRIPTION
# One-line summary

Introduce request level properties in ServiceContext middleware

## Description

Currently, the service owners can modify Props value set via ServiceContext middleware. We use this in our services to set table names at a request level. This causes some issues, since this value is shared across requests, it can possibly overwrite the table name from another request or even throw concurrent write failure for this map.

To solve this, we introduce a new `RequestProps` field, which can be safely written to at the service level, since this value is not shared across all the request. Instead this field would contain a new empty `map[string]interface{}` initialised for every request via the ServiceContext middleware.

This change is also backward compatible, since we're keeping the `Props` field in ServiceContext untouched.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)
- Documentation / non-code


## Review
_List of tasks the reviewer must do to review the PR_
- [x] Tests
- [x] Documentation
- [x] CHANGELOG
