### PR TITLE
refactor(observability): Update observability around tracing & loggin

### DIFF
--- a/config.go
+++ b/config.go
@@ -36,26 +36,26 @@ type Config struct {
 
 // Opts define configuration options for fastecho.
 type Opts struct {
-	Metrics      MetricsOpts
-	Tracing      TracingOpts
-	HealthChecks HealthChecksOpts
+	Metrics      MetricsOpts      `json:"metrics"`
+	Tracing      TracingOpts      `json:"tracing"`
+	HealthChecks HealthChecksOpts `json:"health_checks"`
 }
 
 // MetricsOpts define configuration options for metrics.
 type MetricsOpts struct {
-	Skip bool
+	Skip bool `json:"skip"`
 }
 
 // TracingOpts define configuration options for tracing.
 type TracingOpts struct {
-	Skip        bool
-	ServiceName string
+	Skip        bool   `json:"skip"`
+	ServiceName string `json:"service_name"`
 }
 
 // HealthChecksOpts define configuration options for health checks.
 type HealthChecksOpts struct {
-	Skip bool
-	DB   *gorm.DB
+	Skip bool     `json:"skip"`
+	DB   *gorm.DB `json:"db,omitempty"`
 }
 
 type Plugin struct {

--- a/database.go
+++ b/database.go
@@ -133,6 +133,18 @@ type dbConfig struct {
 	ConnMaxLifetime time.Duration
 }
 
+// gormLogLevel maps a log level string to a gorm logger.LogLevel.
+func gormLogLevel(level string) logger.LogLevel {
+	switch level {
+	case env.ProdLogLevel:
+		return logger.Error
+	case env.TestLogLevel:
+		return logger.Warn
+	default:
+		return logger.Info
+	}
+}
+
 // setup creates a new database based on the configuration given.
 func (c *dbConfig) setup(cfg *gorm.Config) (*gorm.DB, error) {
 	dsn, err := c.buildDSN()
@@ -142,7 +154,7 @@ func (c *dbConfig) setup(cfg *gorm.Config) (*gorm.DB, error) {
 
 	if cfg == nil {
 		cfg = &gorm.Config{
-			Logger: logger.Default.LogMode(logger.Info),
+			Logger: logger.Default.LogMode(gormLogLevel(env.GetLogLevel())),
 		}
 	}
 

--- a/echozap/logger.go
+++ b/echozap/logger.go
@@ -15,49 +15,42 @@
 package echozap
 
 import (
-	"fmt"
-	"os"
-
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/ingka-group/fastecho/env"
 )
 
-const (
-	EnvType = "ENV_TYPE"
-
-	DevEnv  = "dev"
-	TestEnv = "test"
-	ProdEnv = "prod"
-)
-
-// getEnvType() get the env type from the OS env
-func getEnvType() string {
-	envType := os.Getenv(EnvType)
-
-	if envType != DevEnv && envType != TestEnv && envType != ProdEnv {
-		//Fallback with a warning
-		fmt.Printf("no valid %s set, falling back to %s\n", EnvType, DevEnv)
-		envType = DevEnv
+// ZapLevel maps the log level to a zapcore.Level
+func ZapLevel(level string) zapcore.Level {
+	switch level {
+	case env.ProdLogLevel:
+		return zapcore.WarnLevel
+	case env.TestLogLevel:
+		return zapcore.InfoLevel
+	default:
+		return zapcore.DebugLevel
 	}
-
-	return envType
 }
 
-// New provides a logger with sain defaults for logging to server ENVs (dev, test, prod)
+// New provides a logger with sane defaults for logging to server environments (dev, test, prod)
 // It configures a JSON structured logger that writes info messages to stdout
 func New() (*zap.Logger, error) {
-	envType := getEnvType()
+	level := env.GetLogLevel()
 
 	var config zap.Config
-	if envType == ProdEnv {
+	if level == env.ProdLogLevel {
 		config = zap.NewProductionConfig()
-	} else { // TestEnv, DevEnv
+	} else { // TestLogLevel, DevLogLevel
 		config = zap.NewDevelopmentConfig()
 
 		// Custom zap.NewDevelopmentConfig settings
 		config.EncoderConfig = zap.NewProductionEncoderConfig()
 		config.Encoding = "json" // Use structure logging
 	}
+
+	// Override log level based on fastecho logic above
+	config.Level = zap.NewAtomicLevelAt(ZapLevel(level))
 
 	// Use CapitalLevelEncoder in all envs
 	config.EncoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder

--- a/echozap/logger_test.go
+++ b/echozap/logger_test.go
@@ -21,26 +21,28 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/ingka-group/fastecho/env"
 )
 
 func TestNew(t *testing.T) {
 	tests := []struct {
-		name    string
-		envType string
+		name     string
+		logLevel string
 	}{
 		{
-			name:    "ok: log message NO env happy path",
-			envType: "",
+			name:     "ok: log message NO env happy path",
+			logLevel: "",
 		},
 		{
-			name:    "ok: log message PROD env happy path",
-			envType: ProdEnv,
+			name:     "ok: log message PROD level happy path",
+			logLevel: env.ProdLogLevel,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Setenv(EnvType, test.envType)
+			t.Setenv(env.LogLevel, test.logLevel)
 			logger, err := New()
 
 			assert.NoError(t, err)

--- a/env/loglevel.go
+++ b/env/loglevel.go
@@ -1,0 +1,41 @@
+// Copyright © 2024 Ingka Holding B.V. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"fmt"
+	"os"
+)
+
+const (
+	// LogLevel is the environment variable name for the log level.
+	LogLevel = "LOG_LEVEL"
+
+	DevLogLevel  = "dev"
+	TestLogLevel = "test"
+	ProdLogLevel = "prod"
+)
+
+// GetLogLevel reads LOG_LEVEL from the environment and falls back to DevLevel if invalid.
+func GetLogLevel() string {
+	level := os.Getenv(LogLevel)
+
+	if level != DevLogLevel && level != TestLogLevel && level != ProdLogLevel {
+		fmt.Printf("no valid %s set, falling back to %s\n", LogLevel, DevLogLevel)
+		level = DevLogLevel
+	}
+
+	return level
+}

--- a/fastecho.go
+++ b/fastecho.go
@@ -44,17 +44,10 @@ import (
 )
 
 const (
-	hostname = "HOSTNAME"
-	port     = "PORT"
-	envType  = "ENV_TYPE"
-
+	hostname        = "HOSTNAME"
+	port            = "PORT"
 	swaggerUITitle  = "SWAGGER_UI_TITLE"
 	swaggerJSONPath = "SWAGGER_JSON_PATH"
-
-	localEnv = "local"
-	devEnv   = "dev"
-	testEnv  = "test"
-	prodEnv  = "prod"
 )
 
 var (
@@ -67,16 +60,16 @@ var (
 			DefaultValue: "8080",
 			IsInteger:    true,
 		},
-		envType: {
-			DefaultValue: devEnv,
-			OneOf:        []string{localEnv, devEnv, testEnv, prodEnv},
-		},
 		swaggerJSONPath: {
 			// Defines the path to the swagger.json file on the server. This is used by the swagger UI.
 			DefaultValue: "/swagger/swagger.json",
 		},
 		swaggerUITitle: {
 			DefaultValue: "FastEcho Service",
+		},
+		env.LogLevel: {
+			DefaultValue: env.DevLogLevel,
+			OneOf:        []string{env.DevLogLevel, env.TestLogLevel, env.ProdLogLevel},
 		},
 	}
 )
@@ -278,7 +271,6 @@ func (s *server) middlewares(cfg *Config) {
 				return isSwaggerRoute(ctx) || isMetricsRoute(ctx) || isHealthRoute(ctx)
 			}),
 			otel.WithServiceName(cfg.Opts.Tracing.ServiceName),
-			otel.WithEnv(envs[envType].Value),
 		))
 	}
 

--- a/otel/config.go
+++ b/otel/config.go
@@ -35,7 +35,6 @@ type TracerConfig struct {
 	Propagators    propagation.TextMapPropagator
 	Skipper        middleware.Skipper
 	ServiceName    string
-	Env            string
 }
 
 func WithPropagators(propagators propagation.TextMapPropagator) Option {
@@ -67,12 +66,5 @@ func WithSkipper(skipper middleware.Skipper) Option {
 func WithServiceName(serviceName string) Option {
 	return optionFunc(func(cfg *TracerConfig) {
 		cfg.ServiceName = serviceName
-	})
-}
-
-// WithEnv specifies the environment for filtering the spans
-func WithEnv(env string) Option {
-	return optionFunc(func(cfg *TracerConfig) {
-		cfg.Env = env
 	})
 }

--- a/otel/middleware.go
+++ b/otel/middleware.go
@@ -181,7 +181,6 @@ func GetHttpRequestAttributes(c echo.Context, req *http.Request, config *TracerC
 		attribute.String("http.user_agent", userAgent),
 		attribute.String("http.client_ip", clientIP),
 		attribute.String("server.name", config.ServiceName),
-		attribute.String("environment", config.Env),
 	}
 }
 

--- a/tracer.go
+++ b/tracer.go
@@ -27,8 +27,19 @@ import (
 )
 
 // newTracer creates a new OTEL tracer.
+// Resource attributes (e.g. deployment.environment) can be set via OTEL_RESOURCE_ATTRIBUTES.
 func newTracer(serviceName string) (*sdktrace.TracerProvider, *oteltrace.Tracer, error) {
 	exporter, err := otlptracehttp.New(gocontext.Background())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	res, err := resource.New(gocontext.Background(),
+		resource.WithFromEnv(),
+		resource.WithAttributes(
+			semconv.ServiceNameKey.String(serviceName),
+		),
+	)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -36,10 +47,7 @@ func newTracer(serviceName string) (*sdktrace.TracerProvider, *oteltrace.Tracer,
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithBatcher(exporter),
-		sdktrace.WithResource(resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String(serviceName),
-		)),
+		sdktrace.WithResource(res),
 	)
 
 	otel.SetTracerProvider(tp)


### PR DESCRIPTION
# Description

- Introduce `LOG_LEVEL` env variable to control logging on `echozap` and `gorm`
- Allow OTEL to use `OTEL_RESOURCE_ATTRIBUTES` instead of the old `ENV_TYPE` which was hardcoded
- **Deprecate** env variable `ENV_TYPE`


## About `LOG_LEVEL`

There are 3 custom log levels
- `DevLevel`
- `TestLevel`
- `ProdLevel`

Each one represents a deployed environment. These log levels, translate into `echozap` and `gorm` log levels internally.
