### PR TITLE
refactor: Remove `ServiceName` from Tracing Config

### DIFF
--- a/config.go
+++ b/config.go
@@ -48,8 +48,7 @@ type MetricsOpts struct {
 
 // TracingOpts define configuration options for tracing.
 type TracingOpts struct {
-	Skip        bool   `json:"skip"`
-	ServiceName string `json:"service_name"`
+	Skip bool `json:"skip"`
 }
 
 // HealthChecksOpts define configuration options for health checks.

--- a/fastecho.go
+++ b/fastecho.go
@@ -39,7 +39,6 @@ import (
 	"github.com/ingka-group/fastecho/env"
 	"github.com/ingka-group/fastecho/otel"
 	"github.com/ingka-group/fastecho/router"
-	"github.com/ingka-group/fastecho/stringutils"
 )
 
 const (
@@ -253,12 +252,7 @@ func (s *server) config(cfg *Config) error {
 
 	// enable/disable tracing
 	if !cfg.Opts.Tracing.Skip {
-		serviceName := os.Getenv("OTEL_SERVICE_NAME")
-		if stringutils.IsEmpty(serviceName) {
-			return errors.New("OTEL_SERVICE_NAME env var is required when tracing is enabled")
-		}
-
-		tracerProvider, tracer, err = newTracer(serviceName)
+		tracerProvider, tracer, err = newTracer()
 		if err != nil {
 			return err
 		}

--- a/fastecho.go
+++ b/fastecho.go
@@ -37,7 +37,6 @@ import (
 	"github.com/ingka-group/fastecho/context"
 	"github.com/ingka-group/fastecho/echozap"
 	"github.com/ingka-group/fastecho/env"
-	"github.com/ingka-group/fastecho/errs"
 	"github.com/ingka-group/fastecho/otel"
 	"github.com/ingka-group/fastecho/router"
 	"github.com/ingka-group/fastecho/stringutils"
@@ -254,11 +253,12 @@ func (s *server) config(cfg *Config) error {
 
 	// enable/disable tracing
 	if !cfg.Opts.Tracing.Skip {
-		if stringutils.IsEmpty(cfg.Opts.Tracing.ServiceName) {
-			return errs.New("service name not provided for tracing")
+		serviceName := os.Getenv("OTEL_SERVICE_NAME")
+		if stringutils.IsEmpty(serviceName) {
+			return errors.New("OTEL_SERVICE_NAME env var is required when tracing is enabled")
 		}
 
-		tracerProvider, tracer, err = newTracer(cfg.Opts.Tracing.ServiceName)
+		tracerProvider, tracer, err = newTracer(serviceName)
 		if err != nil {
 			return err
 		}
@@ -277,7 +277,6 @@ func (s *server) middlewares(cfg *Config) {
 			otel.WithSkipper(func(ctx echo.Context) bool {
 				return isSwaggerRoute(ctx) || isMetricsRoute(ctx) || isHealthRoute(ctx)
 			}),
-			otel.WithServiceName(cfg.Opts.Tracing.ServiceName),
 		))
 	}
 

--- a/otel/config.go
+++ b/otel/config.go
@@ -34,7 +34,6 @@ type TracerConfig struct {
 	TracerProvider oteltrace.TracerProvider
 	Propagators    propagation.TextMapPropagator
 	Skipper        middleware.Skipper
-	ServiceName    string
 }
 
 func WithPropagators(propagators propagation.TextMapPropagator) Option {
@@ -59,12 +58,5 @@ func WithTracerProvider(provider oteltrace.TracerProvider) Option {
 func WithSkipper(skipper middleware.Skipper) Option {
 	return optionFunc(func(cfg *TracerConfig) {
 		cfg.Skipper = skipper
-	})
-}
-
-// WithServiceName specifies the name of the service
-func WithServiceName(serviceName string) Option {
-	return optionFunc(func(cfg *TracerConfig) {
-		cfg.ServiceName = serviceName
 	})
 }

--- a/otel/middleware.go
+++ b/otel/middleware.go
@@ -103,7 +103,7 @@ func setSpanStatus(span oteltrace.Span, status int) {
 
 func startSpan(c echo.Context, tracer oteltrace.Tracer, ctx context.Context, config *TracerConfig) (context.Context, oteltrace.Span) {
 	opts := []oteltrace.SpanStartOption{
-		oteltrace.WithAttributes(GetHttpRequestAttributes(c, c.Request(), config)...),
+		oteltrace.WithAttributes(GetHttpRequestAttributes(c, c.Request())...),
 		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 	}
 	if path := c.Path(); path != "" {
@@ -131,7 +131,7 @@ func setDefaultConfig(config *TracerConfig) {
 	}
 }
 
-func GetHttpRequestAttributes(c echo.Context, req *http.Request, config *TracerConfig) []attribute.KeyValue {
+func GetHttpRequestAttributes(c echo.Context, req *http.Request) []attribute.KeyValue {
 
 	// http.method
 	method := req.Method
@@ -180,7 +180,6 @@ func GetHttpRequestAttributes(c echo.Context, req *http.Request, config *TracerC
 		attribute.String("net.sock.peer.port", peerPort),
 		attribute.String("http.user_agent", userAgent),
 		attribute.String("http.client_ip", clientIP),
-		attribute.String("server.name", config.ServiceName),
 	}
 }
 

--- a/tracer.go
+++ b/tracer.go
@@ -22,7 +22,6 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.9.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
@@ -36,9 +35,6 @@ func newTracer(serviceName string) (*sdktrace.TracerProvider, *oteltrace.Tracer,
 
 	res, err := resource.New(gocontext.Background(),
 		resource.WithFromEnv(),
-		resource.WithAttributes(
-			semconv.ServiceNameKey.String(serviceName),
-		),
 	)
 	if err != nil {
 		return nil, nil, err

--- a/tracer.go
+++ b/tracer.go
@@ -26,8 +26,9 @@ import (
 )
 
 // newTracer creates a new OTEL tracer.
+// Service name is read from OTEL_SERVICE_NAME env var via resource.WithFromEnv().
 // Resource attributes (e.g. deployment.environment) can be set via OTEL_RESOURCE_ATTRIBUTES.
-func newTracer(serviceName string) (*sdktrace.TracerProvider, *oteltrace.Tracer, error) {
+func newTracer() (*sdktrace.TracerProvider, *oteltrace.Tracer, error) {
 	exporter, err := otlptracegrpc.New(gocontext.Background())
 	if err != nil {
 		return nil, nil, err
@@ -53,6 +54,6 @@ func newTracer(serviceName string) (*sdktrace.TracerProvider, *oteltrace.Tracer,
 		),
 	)
 
-	tracer := tp.Tracer(serviceName)
+	tracer := tp.Tracer("github.com/ingka-group/fastecho")
 	return tp, &tracer, nil
 }


### PR DESCRIPTION
# Description

- Remove the `ServiceName` from tracing configuration - `OTEL_SERVICE_NAME` is the official valued handled in the OTEL SDK - no need to wrap this 
- Remove the `ServiceName` from getting printed to the traces (it's not required and it adds noise)