### PR TITLE
chore: improve echo recovery with zap logging the stack trace

### DIFF
--- a/fastecho.go
+++ b/fastecho.go
@@ -307,7 +307,24 @@ func (s *server) middlewares(cfg *Config) {
 	}
 
 	// Recover
-	s.Echo.Use(middleware.Recover())
+	s.Echo.Use(middleware.RecoverWithConfig(middleware.RecoverConfig{
+		DisablePrintStack: true,
+		LogErrorFunc: func(c echo.Context, err error, stack []byte) error {
+			req := c.Request()
+			spanCtx := trace.SpanContextFromContext(req.Context())
+			s.Logger.Error("panic recovered",
+				zap.Error(err),
+				zap.String("method", req.Method),
+				zap.String("path", c.Path()),
+				zap.String("uri", req.RequestURI),
+				zap.String("request_id", c.Response().Header().Get(echo.HeaderXRequestID)),
+				zap.String("trace_id", spanCtx.TraceID().String()),
+				zap.String("span_id", spanCtx.SpanID().String()),
+				zap.ByteString("stack", stack),
+			)
+			return err
+		},
+	}))
 }
 
 // run starts the server and listens for interrupt signals to gracefully shut it down.


### PR DESCRIPTION
# One-line summary

Use Zap Logger to output the stack trace when an echo request panics for better debugging. 

## Description

- Combines Echo's middleware for Recover after panic with the fastecho configured ZapLogger. 

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Refactor/improvements