### PR TITLE
fix: handle SIGTERM and flush logs on graceful shutdown

### DIFF
--- a/echozap/logger.go
+++ b/echozap/logger.go
@@ -66,9 +66,5 @@ func New() (*zap.Logger, error) {
 		return nil, err
 	}
 
-	defer func(zapLogger *zap.Logger) {
-		_ = zapLogger.Sync()
-	}(zapLogger)
-
 	return zapLogger, nil
 }

--- a/fastecho.go
+++ b/fastecho.go
@@ -15,14 +15,16 @@
 package fastecho
 
 import (
-	gocontext "context"
+	"context"
 	"errors"
 	"fmt"
 	"maps"
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/google/uuid"
@@ -128,7 +130,7 @@ func (fe *FastEcho) Handler() http.Handler {
 }
 
 // Shutdown cleanly shuts down the server and any tracing providers.
-func (fe *FastEcho) Shutdown(ctx gocontext.Context) error {
+func (fe *FastEcho) Shutdown(ctx context.Context) error {
 	if fe.server.TracerProvider != nil {
 		_ = fe.server.TracerProvider.Shutdown(ctx)
 	}
@@ -342,32 +344,48 @@ func (s *server) middlewares(cfg *Config) {
 
 // run starts the server and listens for interrupt signals to gracefully shut it down.
 func (s *server) run(host string, port string) error {
+	// Catch-all for crashes the runtime can still report: on a runtime-fatal
+	// error (stack overflow, concurrent map writes, out-of-memory, etc.) or an
+	// unrecovered panic, the runtime writes a full stack dump to stderr before
+	// exiting. "all" includes every goroutine, not just the offending one, so a
+	// restarted service always leaves a traceable cause in the logs. Mirrors
+	// GOTRACEBACK=all without relying on the deployment to set it. Note: this
+	// cannot help on SIGKILL / kernel OOM-kill, where the process dies instantly.
+	debug.SetTraceback("all")
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	return s.serve(ctx, host, port)
+}
+
+// serve starts the HTTP server and shuts it down gracefully once ctx is done.
+func (s *server) serve(ctx context.Context, host string, port string) error {
 	// Defer the shutdown of the tracer provider
 	defer func() {
 		if s.TracerProvider != nil {
-			_ = s.TracerProvider.Shutdown(gocontext.Background())
+			_ = s.TracerProvider.Shutdown(context.Background())
 		}
 	}()
+
+	// Flush buffered logs on the way out
+	defer func() { _ = s.Logger.Sync() }()
 
 	// Start server
 	go func() {
 		serviceURL := fmt.Sprintf("%s:%v", host, port)
-		if err := s.Echo.Start(serviceURL); err != nil && err != http.ErrServerClosed {
+		if err := s.Echo.Start(serviceURL); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			s.Echo.Logger.Panicf("Shutting down the server! \n%s", err)
 		}
 	}()
 
-	// Wait for interrupt signal to gracefully shut down the server with a timeout of 10 seconds.
-	// Use a buffered channel to avoid missing signals as recommended for signal.Notify
-	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, os.Interrupt)
-	<-quit
+	// Wait for the shutdown signal, then drain in-flight requests with a 10s timeout.
+	<-ctx.Done()
 
-	ctx, cancel := gocontext.WithTimeout(gocontext.Background(), 10*time.Second)
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	err := s.Echo.Shutdown(ctx)
-	return err
+	return s.Echo.Shutdown(shutdownCtx)
 }
 
 // isMetricsRoute returns whether the request is to metrics endpoint.

--- a/fastecho_test.go
+++ b/fastecho_test.go
@@ -1,0 +1,101 @@
+// Copyright © 2024 Ingka Holding B.V. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fastecho
+
+import (
+	gocontext "context"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// newTestServer returns a minimal server backed by a no-op logger and a fresh
+// Echo, suitable for exercising the shutdown lifecycle without tracing or
+// metrics wiring.
+func newTestServer() *server {
+	return &server{
+		Echo:   echo.New(),
+		Logger: zap.NewNop(),
+	}
+}
+
+// waitForReturn fails the test if serve/run does not return within the timeout.
+func waitForReturn(t *testing.T, errc <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-errc:
+		return err
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not shut down within timeout")
+		return nil
+	}
+}
+
+func TestServeShutsDownWhenContextCancelled(t *testing.T) {
+	s := newTestServer()
+	ctx, cancel := gocontext.WithCancel(gocontext.Background())
+
+	errc := make(chan error, 1)
+	go func() {
+		errc <- s.serve(ctx, "localhost", "0")
+	}()
+
+	// Give the listener a moment to bind before triggering shutdown.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	assert.NoError(t, waitForReturn(t, errc))
+}
+
+func TestRunShutsDownOnSIGTERM(t *testing.T) {
+	s := newTestServer()
+
+	errc := make(chan error, 1)
+	go func() {
+		errc <- s.run("localhost", "0")
+	}()
+
+	// Allow run() to register the signal handler and the listener to bind.
+	time.Sleep(100 * time.Millisecond)
+
+	p, err := os.FindProcess(os.Getpid())
+	require.NoError(t, err)
+	require.NoError(t, p.Signal(syscall.SIGTERM))
+
+	assert.NoError(t, waitForReturn(t, errc))
+}
+
+func TestRunShutsDownOnSIGINT(t *testing.T) {
+	s := newTestServer()
+
+	errc := make(chan error, 1)
+	go func() {
+		errc <- s.run("localhost", "0")
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	p, err := os.FindProcess(os.Getpid())
+	require.NoError(t, err)
+	require.NoError(t, p.Signal(syscall.SIGINT))
+
+	assert.NoError(t, waitForReturn(t, errc))
+}

--- a/fastecho_test.go
+++ b/fastecho_test.go
@@ -16,7 +16,12 @@ package fastecho
 
 import (
 	gocontext "context"
+	"io"
+	"net"
+	"net/http"
 	"os"
+	"strconv"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -25,11 +30,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
-// newTestServer returns a minimal server backed by a no-op logger and a fresh
-// Echo, suitable for exercising the shutdown lifecycle without tracing or
-// metrics wiring.
+// newTestServer builds a bare server with a no-op logger, enough to test
+// startup and shutdown.
 func newTestServer() *server {
 	return &server{
 		Echo:   echo.New(),
@@ -37,7 +42,35 @@ func newTestServer() *server {
 	}
 }
 
-// waitForReturn fails the test if serve/run does not return within the timeout.
+// freePort grabs a free port and returns it. Tests use it so they can wait
+// for the server to come up instead of guessing with a sleep.
+func freePort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	p := strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
+	require.NoError(t, ln.Close())
+	return p
+}
+
+// waitUntilServing waits until the server accepts a connection on addr. In
+// run() the signal handler is set up before the server starts listening, so
+// once we can connect we know the handler is ready too.
+func waitUntilServing(t *testing.T, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("server did not start listening on %s within timeout", addr)
+}
+
+// waitForReturn fails the test if the server does not stop in time.
 func waitForReturn(t *testing.T, errc <-chan error) error {
 	t.Helper()
 	select {
@@ -51,51 +84,144 @@ func waitForReturn(t *testing.T, errc <-chan error) error {
 
 func TestServeShutsDownWhenContextCancelled(t *testing.T) {
 	s := newTestServer()
+	p := freePort(t)
 	ctx, cancel := gocontext.WithCancel(gocontext.Background())
 
 	errc := make(chan error, 1)
 	go func() {
-		errc <- s.serve(ctx, "localhost", "0")
+		errc <- s.serve(ctx, "localhost", p)
 	}()
 
-	// Give the listener a moment to bind before triggering shutdown.
-	time.Sleep(50 * time.Millisecond)
+	waitUntilServing(t, net.JoinHostPort("localhost", p))
 	cancel()
 
 	assert.NoError(t, waitForReturn(t, errc))
 }
 
-func TestRunShutsDownOnSIGTERM(t *testing.T) {
+func TestRunShutsDownOnSignal(t *testing.T) {
+	// Signals hit the whole process, so run these one at a time (no
+	// t.Parallel): each run() adds a handler and removes it when it returns.
+	signals := map[string]syscall.Signal{
+		"sigterm": syscall.SIGTERM,
+		"sigint":  syscall.SIGINT,
+	}
+
+	for name, sig := range signals {
+		t.Run(name, func(t *testing.T) {
+			s := newTestServer()
+			p := freePort(t)
+
+			errc := make(chan error, 1)
+			go func() {
+				errc <- s.run("localhost", p)
+			}()
+
+			waitUntilServing(t, net.JoinHostPort("localhost", p))
+
+			pr, err := os.FindProcess(os.Getpid())
+			require.NoError(t, err)
+			require.NoError(t, pr.Signal(sig))
+
+			assert.NoError(t, waitForReturn(t, errc))
+		})
+	}
+}
+
+func TestServeWaitsForInFlightRequest(t *testing.T) {
 	s := newTestServer()
+
+	started := make(chan struct{})
+	s.Echo.GET("/slow", func(c echo.Context) error {
+		close(started)
+		time.Sleep(200 * time.Millisecond)
+		return c.String(http.StatusOK, "done")
+	})
+
+	p := freePort(t)
+	ctx, cancel := gocontext.WithCancel(gocontext.Background())
 
 	errc := make(chan error, 1)
 	go func() {
-		errc <- s.run("localhost", "0")
+		errc <- s.serve(ctx, "localhost", p)
 	}()
 
-	// Allow run() to register the signal handler and the listener to bind.
-	time.Sleep(100 * time.Millisecond)
+	addr := net.JoinHostPort("localhost", p)
+	waitUntilServing(t, addr)
 
-	p, err := os.FindProcess(os.Getpid())
-	require.NoError(t, err)
-	require.NoError(t, p.Signal(syscall.SIGTERM))
+	respc := make(chan *http.Response, 1)
+	reqErrc := make(chan error, 1)
+	go func() {
+		resp, err := http.Get("http://" + addr + "/slow")
+		if err != nil {
+			reqErrc <- err
+			return
+		}
+		respc <- resp
+	}()
+
+	// Start shutdown only after the request has reached the handler.
+	<-started
+	cancel()
+
+	select {
+	case resp := <-respc:
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "done", string(body))
+	case err := <-reqErrc:
+		t.Fatalf("in-flight request was dropped instead of drained: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("in-flight request did not complete")
+	}
 
 	assert.NoError(t, waitForReturn(t, errc))
 }
 
-func TestRunShutsDownOnSIGINT(t *testing.T) {
-	s := newTestServer()
+func TestServeFlushesLogsOnShutdown(t *testing.T) {
+	rec := &recordingSyncer{}
+	core := zapcore.NewCore(
+		zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+		zapcore.AddSync(rec),
+		zapcore.InfoLevel,
+	)
+	s := &server{
+		Echo:   echo.New(),
+		Logger: zap.New(core),
+	}
+
+	p := freePort(t)
+	ctx, cancel := gocontext.WithCancel(gocontext.Background())
 
 	errc := make(chan error, 1)
 	go func() {
-		errc <- s.run("localhost", "0")
+		errc <- s.serve(ctx, "localhost", p)
 	}()
 
-	time.Sleep(100 * time.Millisecond)
+	waitUntilServing(t, net.JoinHostPort("localhost", p))
+	cancel()
 
-	p, err := os.FindProcess(os.Getpid())
-	require.NoError(t, err)
-	require.NoError(t, p.Signal(syscall.SIGINT))
+	require.NoError(t, waitForReturn(t, errc))
+	assert.True(t, rec.didSync(), "expected Logger.Sync to be called on the shutdown path")
+}
 
-	assert.NoError(t, waitForReturn(t, errc))
+// recordingSyncer is a fake log writer that just remembers if Sync was called.
+type recordingSyncer struct {
+	mu     sync.Mutex
+	synced bool
+}
+
+func (r *recordingSyncer) Write(p []byte) (int, error) { return len(p), nil }
+
+func (r *recordingSyncer) Sync() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.synced = true
+	return nil
+}
+
+func (r *recordingSyncer) didSync() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.synced
 }


### PR DESCRIPTION
# Handle SIGTERM and flush logs on graceful shutdown

## Description
The server only listened for `SIGINT`, so `SIGTERM` (what Kubernetes and Docker send first) never triggered a graceful shutdown. On top of that, the zap logger was flushed at construction instead of on exit, so the last log lines before a shutdown or crash were lost.

This PR:
- Listens for both `os.Interrupt` and `syscall.SIGTERM` via `signal.NotifyContext` so orchestrated shutdowns drain gracefully.
- Flushes the logger on the shutdown path instead of at construction.
- Sets `debug.SetTraceback("all")` so runtime-fatal crashes dump every goroutine to stderr.

SIGKILL and kernel OOM-kill stay out of scope (uncatchable in-process), and the shutdown timeout stays at 10s.

## Types of Changes
- Bug fix (non-breaking change which fixes an issue)

## Tasks
- [x] Listen for SIGTERM in addition to SIGINT
- [x] Flush logger on shutdown
- [x] Dump all goroutines on runtime-fatal crashes
- [x] Tests covering context- and signal-driven shutdown, in-flight request draining, and log flushing

## Review
- [x] Tests
- [x] Documentation
- [x] CHANGELOG

## Deployment Notes
Capture the process's stderr — runtime crash tracebacks are written there, not through the application logger.
