### PR TITLE
feat: supervise background workers with self-restart and backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ config := fastecho.Config{
 }
 ```
 
-Workers are supervised: since a worker should block until its context is cancelled, any early return (error, `nil`, or a recovered panic) is treated as a fault and the worker is restarted with exponential backoff (1s, doubling, capped at 30s; reset after 1m stable). Only a context-cancelled return is a clean stop — no restart, no error log. Other workers and the HTTP server are unaffected.
+Workers are supervised: since a worker should block until its context is cancelled, any early return (error, `nil`, or a recovered panic) is treated as a fault and the worker is restarted with exponential backoff (1s, doubling, capped at 30s; reset after 1m stable). Restarts are logged at warning level; once a worker has restarted 10 times without a stable run the log escalates to error, so a persistent crash loop can be distinguished from an occasional restart by anything consuming the logs. Only a context-cancelled return is a clean stop — no restart, no error log. Other workers and the HTTP server are unaffected.
 
 ## Plugins
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ config := fastecho.Config{
 }
 ```
 
-A worker that returns an error or panics is logged and recovered; the server and other workers keep running.
+Workers are supervised: since a worker should block until its context is cancelled, any early return (error, `nil`, or a recovered panic) is treated as a fault and the worker is restarted with exponential backoff (1s, doubling, capped at 30s; reset after 1m stable). Only a context-cancelled return is a clean stop — no restart, no error log. Other workers and the HTTP server are unaffected.
 
 ## Plugins
 

--- a/fastecho.go
+++ b/fastecho.go
@@ -83,6 +83,10 @@ type server struct {
 	Tracer         *trace.Tracer
 	TracerProvider *sdktrace.TracerProvider
 	Workers        []Worker
+
+	workerInitialRestartDelay  time.Duration
+	workerMaxRestartDelay      time.Duration
+	workerStableResetThreshold time.Duration
 }
 
 type FastEcho struct {
@@ -153,7 +157,11 @@ func BindValidate(ec echo.Context, v any) error {
 
 func newServer(cfg *Config) (*server, error) {
 	// Set up the server
-	s := &server{}
+	s := &server{
+		workerInitialRestartDelay:  1 * time.Second,
+		workerMaxRestartDelay:      30 * time.Second,
+		workerStableResetThreshold: 1 * time.Minute,
+	}
 
 	// If no configuration is passed,
 	// the service should still run with default values

--- a/fastecho.go
+++ b/fastecho.go
@@ -51,6 +51,13 @@ const (
 	swaggerJSONPath = "SWAGGER_JSON_PATH"
 )
 
+const (
+	defaultWorkerInitialRestartDelay  = 1 * time.Second
+	defaultWorkerMaxRestartDelay      = 30 * time.Second
+	defaultWorkerStableResetThreshold = 1 * time.Minute
+	defaultWorkerCrashLoopThreshold   = 10
+)
+
 var (
 	// Environment variables for fastecho to operate.
 	envs = env.Map{
@@ -87,6 +94,7 @@ type server struct {
 	workerInitialRestartDelay  time.Duration
 	workerMaxRestartDelay      time.Duration
 	workerStableResetThreshold time.Duration
+	workerCrashLoopThreshold   int
 }
 
 type FastEcho struct {
@@ -158,9 +166,10 @@ func BindValidate(ec echo.Context, v any) error {
 func newServer(cfg *Config) (*server, error) {
 	// Set up the server
 	s := &server{
-		workerInitialRestartDelay:  1 * time.Second,
-		workerMaxRestartDelay:      30 * time.Second,
-		workerStableResetThreshold: 1 * time.Minute,
+		workerInitialRestartDelay:  defaultWorkerInitialRestartDelay,
+		workerMaxRestartDelay:      defaultWorkerMaxRestartDelay,
+		workerStableResetThreshold: defaultWorkerStableResetThreshold,
+		workerCrashLoopThreshold:   defaultWorkerCrashLoopThreshold,
 	}
 
 	// If no configuration is passed,

--- a/fastecho_test.go
+++ b/fastecho_test.go
@@ -39,6 +39,10 @@ func newTestServer() *server {
 	return &server{
 		Echo:   echo.New(),
 		Logger: zap.NewNop(),
+
+		workerInitialRestartDelay:  1 * time.Millisecond,
+		workerMaxRestartDelay:      10 * time.Millisecond,
+		workerStableResetThreshold: 1 * time.Second,
 	}
 }
 

--- a/fastecho_test.go
+++ b/fastecho_test.go
@@ -43,6 +43,7 @@ func newTestServer() *server {
 		workerInitialRestartDelay:  1 * time.Millisecond,
 		workerMaxRestartDelay:      10 * time.Millisecond,
 		workerStableResetThreshold: 1 * time.Second,
+		workerCrashLoopThreshold:   10,
 	}
 }
 

--- a/worker.go
+++ b/worker.go
@@ -20,7 +20,6 @@ import (
 	"runtime/debug"
 	"sync"
 
-	"github.com/ingka-group/fastecho/fctx"
 	"go.uber.org/zap"
 
 	"github.com/ingka-group/fastecho/fctx"

--- a/worker.go
+++ b/worker.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"runtime/debug"
 	"sync"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -29,9 +30,37 @@ import (
 // It should block until ctx is cancelled, returning ctx.Err() (or nil) on shutdown.
 type Worker func(ctx context.Context) error
 
-// runWorker runs a single worker, recovering panics and logging any error so
-// that one worker cannot crash the process or affect the others.
+// runWorker supervises a worker for the lifetime of ctx, restarting it with
+// capped exponential backoff on any early return so a crashed worker is never
+// left silently dead until shutdown. It exits only when ctx is cancelled.
 func (s *server) runWorker(ctx context.Context, w Worker) {
+	delay := s.workerInitialRestartDelay
+	for {
+		start := time.Now()
+		s.runWorkerOnce(ctx, w)
+		if ctx.Err() != nil {
+			return
+		}
+
+		if time.Since(start) >= s.workerStableResetThreshold {
+			delay = s.workerInitialRestartDelay
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(delay):
+		}
+
+		// After the wait, so cancelling during backoff exits without a misleading log.
+		s.Logger.Warn("restarting worker", zap.Duration("backoff", delay))
+		delay = min(delay*2, s.workerMaxRestartDelay)
+	}
+}
+
+// runWorkerOnce runs a worker exactly once, recovering panics and logging any
+// error so that one worker cannot crash the process or affect the others.
+func (s *server) runWorkerOnce(ctx context.Context, w Worker) {
 	ctx = fctx.WithLogger(ctx, s.Logger)
 	if s.Tracer != nil {
 		ctx = fctx.WithTracer(ctx, *s.Tracer)
@@ -46,8 +75,7 @@ func (s *server) runWorker(ctx context.Context, w Worker) {
 		}
 	}()
 
-	// A cancelled context is the documented, expected way for a worker to stop
-	// on shutdown, so it is not an error worth alerting on.
+	// A cancelled context is the expected shutdown signal, not an error.
 	if err := w(ctx); err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 		s.Logger.Error("worker exited with error", zap.Error(err))
 	}
@@ -57,9 +85,8 @@ func (s *server) runWorker(ctx context.Context, w Worker) {
 // drain in time it logs a warning and returns anyway.
 func (s *server) drainWorkers(ctx context.Context, workers *sync.WaitGroup) {
 	done := make(chan struct{})
-	// If a worker ignores cancellation this goroutine stays blocked on Wait
-	// forever; that is acceptable because drainWorkers only runs once as the
-	// process exits, and a WaitGroup offers no way to abandon the wait.
+	// A worker that ignores cancellation leaks this goroutine, which is
+	// acceptable: drainWorkers runs only as the process exits.
 	go func() {
 		workers.Wait()
 		close(done)

--- a/worker.go
+++ b/worker.go
@@ -35,6 +35,7 @@ type Worker func(ctx context.Context) error
 // left silently dead until shutdown. It exits only when ctx is cancelled.
 func (s *server) runWorker(ctx context.Context, w Worker) {
 	delay := s.workerInitialRestartDelay
+	failures := 0
 	for {
 		start := time.Now()
 		s.runWorkerOnce(ctx, w)
@@ -44,16 +45,26 @@ func (s *server) runWorker(ctx context.Context, w Worker) {
 
 		if time.Since(start) >= s.workerStableResetThreshold {
 			delay = s.workerInitialRestartDelay
+			failures = 0
 		}
 
+		timer := time.NewTimer(delay)
 		select {
 		case <-ctx.Done():
+			timer.Stop()
 			return
-		case <-time.After(delay):
+		case <-timer.C:
 		}
 
-		// After the wait, so cancelling during backoff exits without a misleading log.
-		s.Logger.Warn("restarting worker", zap.Duration("backoff", delay))
+		failures++
+		logRestart := s.Logger.Warn
+		if failures >= s.workerCrashLoopThreshold {
+			logRestart = s.Logger.Error
+		}
+		logRestart("restarting worker",
+			zap.Duration("backoff", delay),
+			zap.Int("failures", failures),
+		)
 		delay = min(delay*2, s.workerMaxRestartDelay)
 	}
 }

--- a/worker.go
+++ b/worker.go
@@ -20,6 +20,7 @@ import (
 	"runtime/debug"
 	"sync"
 
+	"github.com/ingka-group/fastecho/fctx"
 	"go.uber.org/zap"
 
 	"github.com/ingka-group/fastecho/fctx"

--- a/worker_test.go
+++ b/worker_test.go
@@ -24,7 +24,6 @@ import (
 	"testing/synctest"
 	"time"
 
-	"github.com/ingka-group/fastecho/fctx"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/worker_test.go
+++ b/worker_test.go
@@ -24,6 +24,7 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/ingka-group/fastecho/fctx"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/worker_test.go
+++ b/worker_test.go
@@ -46,6 +46,7 @@ func newObserverServer() (*server, *observer.ObservedLogs) {
 		workerInitialRestartDelay:  1 * time.Millisecond,
 		workerMaxRestartDelay:      10 * time.Millisecond,
 		workerStableResetThreshold: 1 * time.Second,
+		workerCrashLoopThreshold:   10,
 	}, logs
 }
 
@@ -397,6 +398,37 @@ func TestRunWorkerResetsBackoffAfterStableRun(t *testing.T) {
 		assert.Equal(t, time.Millisecond, entries[0].ContextMap()["backoff"])
 		assert.Equal(t, time.Millisecond, entries[1].ContextMap()["backoff"],
 			"backoff must reset to the initial delay after a stable run")
+
+		cancel()
+		synctest.Wait()
+	})
+}
+
+func TestRunWorkerEscalatesLogAfterCrashLoopThreshold(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		s, logs := newObserverServer()
+		s.workerCrashLoopThreshold = 3
+		var calls atomic.Int32
+		healthy := make(chan struct{})
+		ctx, cancel := context.WithCancel(context.Background())
+
+		go s.runWorker(ctx, func(ctx context.Context) error {
+			if calls.Add(1) <= 3 {
+				return errors.New("boom")
+			}
+			close(healthy)
+			<-ctx.Done()
+			return ctx.Err()
+		})
+
+		<-healthy
+		synctest.Wait()
+
+		// Three failures, three restart logs: the first two stay at Warn, the
+		// third reaches the threshold and is escalated to Error for alerting.
+		restarts := logs.FilterMessage("restarting worker")
+		assert.Equal(t, 2, restarts.FilterLevelExact(zapcore.WarnLevel).Len())
+		assert.Equal(t, 1, restarts.FilterLevelExact(zapcore.ErrorLevel).Len())
 
 		cancel()
 		synctest.Wait()

--- a/worker_test.go
+++ b/worker_test.go
@@ -41,8 +41,11 @@ import (
 func newObserverServer() (*server, *observer.ObservedLogs) {
 	core, logs := observer.New(zapcore.InfoLevel)
 	return &server{
-		Echo:   echo.New(),
-		Logger: zap.New(core),
+		Echo:                       echo.New(),
+		Logger:                     zap.New(core),
+		workerInitialRestartDelay:  1 * time.Millisecond,
+		workerMaxRestartDelay:      10 * time.Millisecond,
+		workerStableResetThreshold: 1 * time.Second,
 	}, logs
 }
 
@@ -106,7 +109,7 @@ func TestServeWaitsForWorkersOnShutdown(t *testing.T) {
 	assert.True(t, drained.Load(), "serve returned before worker finished draining")
 }
 
-func TestServeKeepsRunningWhenWorkerErrorsOrPanics(t *testing.T) {
+func TestServeSurvivesFailingWorkers(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	s := newTestServer()
 	healthy := make(chan struct{})
@@ -144,7 +147,7 @@ func TestServeKeepsRunningWhenWorkerErrorsOrPanics(t *testing.T) {
 	assert.NoError(t, waitForReturn(t, errc))
 }
 
-func TestRunWorker(t *testing.T) {
+func TestRunWorkerOnce(t *testing.T) {
 	tests := []struct {
 		name        string
 		worker      Worker
@@ -179,7 +182,7 @@ func TestRunWorker(t *testing.T) {
 			s, logs := newObserverServer()
 
 			assert.NotPanics(t, func() {
-				s.runWorker(context.Background(), tt.worker)
+				s.runWorkerOnce(context.Background(), tt.worker)
 			})
 
 			if tt.wantMessage == "" {
@@ -206,7 +209,7 @@ func (stubTracer) Start(ctx context.Context, _ string, _ ...trace.SpanStartOptio
 func TestRunWorkerInjectsLogger(t *testing.T) {
 	s, logs := newObserverServer()
 
-	s.runWorker(context.Background(), func(ctx context.Context) error {
+	s.runWorkerOnce(context.Background(), func(ctx context.Context) error {
 		fctx.Logger(ctx).Info("from worker")
 		return nil
 	})
@@ -221,13 +224,183 @@ func TestRunWorkerInjectsTracer(t *testing.T) {
 	s.Tracer = &tracer
 
 	var got trace.Tracer
-	s.runWorker(context.Background(), func(ctx context.Context) error {
+	s.runWorkerOnce(context.Background(), func(ctx context.Context) error {
 		got = fctx.Tracer(ctx)
 		return nil
 	})
 
 	assert.IsType(t, stubTracer{}, got,
 		"worker context should carry the server tracer, not the no-op fallback")
+}
+
+func TestRunWorkerRestartsAfterFailuresThenStabilizes(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		s, logs := newObserverServer()
+		var calls atomic.Int32
+		healthy := make(chan struct{})
+		ctx, cancel := context.WithCancel(context.Background())
+
+		go s.runWorker(ctx, func(ctx context.Context) error {
+			if calls.Add(1) < 3 {
+				return errors.New("boom")
+			}
+			close(healthy)
+			<-ctx.Done()
+			return ctx.Err()
+		})
+
+		<-healthy
+		synctest.Wait()
+		assert.Equal(t, int32(3), calls.Load())
+		assert.Equal(t, 2, logs.FilterMessage("restarting worker").Len())
+
+		cancel()
+		synctest.Wait()
+	})
+}
+
+func TestRunWorkerRestartsAfterPanic(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		s, logs := newObserverServer()
+		var calls atomic.Int32
+		healthy := make(chan struct{})
+		ctx, cancel := context.WithCancel(context.Background())
+
+		go s.runWorker(ctx, func(ctx context.Context) error {
+			if calls.Add(1) == 1 {
+				panic("kaboom")
+			}
+			close(healthy)
+			<-ctx.Done()
+			return ctx.Err()
+		})
+
+		<-healthy
+		synctest.Wait()
+		assert.Equal(t, 1, logs.FilterMessage("worker panic recovered").Len())
+		assert.GreaterOrEqual(t, logs.FilterMessage("restarting worker").Len(), 1)
+
+		cancel()
+		synctest.Wait()
+	})
+}
+
+func TestRunWorkerRestartsAfterCleanReturn(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		s, _ := newObserverServer()
+		var calls atomic.Int32
+		healthy := make(chan struct{})
+		ctx, cancel := context.WithCancel(context.Background())
+
+		go s.runWorker(ctx, func(ctx context.Context) error {
+			if calls.Add(1) == 1 {
+				return nil
+			}
+			close(healthy)
+			<-ctx.Done()
+			return ctx.Err()
+		})
+
+		<-healthy
+		synctest.Wait()
+		assert.GreaterOrEqual(t, calls.Load(), int32(2),
+			"a clean return while ctx is live should be treated as a fault and restarted")
+
+		cancel()
+		synctest.Wait()
+	})
+}
+
+func TestRunWorkerStopsOnContextCancel(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		s, logs := newObserverServer()
+		running := make(chan struct{})
+		done := make(chan struct{})
+		ctx, cancel := context.WithCancel(context.Background())
+
+		go func() {
+			s.runWorker(ctx, func(ctx context.Context) error {
+				close(running)
+				<-ctx.Done()
+				return ctx.Err()
+			})
+			close(done)
+		}()
+
+		<-running
+		cancel()
+		<-done
+		synctest.Wait()
+		assert.Equal(t, 0, logs.FilterMessage("restarting worker").Len(),
+			"a worker stopped by shutdown must not be reported as restarting")
+		assert.Equal(t, 0, logs.FilterMessage("worker exited with error").Len())
+	})
+}
+
+func TestRunWorkerCancelDuringBackoffReturnsPromptly(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		s, logs := newObserverServer()
+		s.workerInitialRestartDelay = time.Hour
+		s.workerMaxRestartDelay = time.Hour
+		var calls atomic.Int32
+		failed := make(chan struct{})
+		done := make(chan struct{})
+		ctx, cancel := context.WithCancel(context.Background())
+
+		go func() {
+			s.runWorker(ctx, func(ctx context.Context) error {
+				calls.Add(1)
+				close(failed)
+				return errors.New("boom")
+			})
+			close(done)
+		}()
+
+		<-failed
+		cancel()
+		<-done
+		synctest.Wait()
+		assert.Equal(t, int32(1), calls.Load(),
+			"cancelling during backoff must not wait out the (1h) delay or restart")
+		assert.Equal(t, 0, logs.FilterMessage("restarting worker").Len())
+	})
+}
+
+func TestRunWorkerResetsBackoffAfterStableRun(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		s, logs := newObserverServer()
+		s.workerInitialRestartDelay = time.Millisecond
+		s.workerMaxRestartDelay = time.Second
+		s.workerStableResetThreshold = time.Second
+		var calls atomic.Int32
+		healthy := make(chan struct{})
+		ctx, cancel := context.WithCancel(context.Background())
+
+		go s.runWorker(ctx, func(ctx context.Context) error {
+			switch calls.Add(1) {
+			case 1:
+				return errors.New("boom")
+			case 2:
+				time.Sleep(2 * time.Second) // outlasts the stable-reset threshold
+				return errors.New("boom again")
+			default:
+				close(healthy)
+				<-ctx.Done()
+				return ctx.Err()
+			}
+		})
+
+		<-healthy
+		synctest.Wait()
+		entries := logs.FilterMessage("restarting worker").All()
+		require.Len(t, entries, 2)
+		assert.Equal(t, time.Millisecond, entries[0].ContextMap()["backoff"])
+		assert.Equal(t, time.Millisecond, entries[1].ContextMap()["backoff"],
+			"backoff must reset to the initial delay after a stable run")
+
+		cancel()
+		synctest.Wait()
+	})
 }
 
 func TestDrainWorkersWaitsForCompletion(t *testing.T) {


### PR DESCRIPTION
Stacked on `feat/inject-logger-tracer-into-worker-context` — review that first; this targets it as base.

## Description
A worker blocks until its context is cancelled, so any early return used to leave the goroutine silently dead until process restart (e.g. a Pub/Sub subscription that quietly stops consuming).

Workers are now supervised: an early return — error, `nil`, or recovered panic — while the context is live is restarted with capped exponential backoff (1s, doubling, max 30s; reset after 1m stable). Only a context-cancelled return is a clean stop. Backoff timings are unexported `server` fields, overridden only in tests — no new public config.

## Types of Changes
- New feature (non-breaking)

## Review
- [x] Tests — `make test` green, `-race` clean
- [x] Documentation — README "Background workers" updated
- [x] CHANGELOG