### PR TITLE
feat(otel): foundation — fctx.Fields + telemetry package rename

### DIFF
--- a/fastecho.go
+++ b/fastecho.go
@@ -28,7 +28,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/labstack/echo-contrib/echoprometheus"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -311,7 +310,7 @@ func (s *server) middlewares(cfg *Config) {
 			return isSwaggerRoute(ctx) || isMetricsRoute(ctx) || isHealthRoute(ctx)
 		},
 		Generator: func() string {
-			return uuid.New().String()
+			return fctx.NewRequestID()
 		},
 	}))
 
@@ -346,17 +345,14 @@ func (s *server) middlewares(cfg *Config) {
 		DisablePrintStack: true,
 		LogErrorFunc: func(c echo.Context, err error, stack []byte) error {
 			req := c.Request()
-			spanCtx := trace.SpanContextFromContext(req.Context())
-			s.Logger.Error("panic recovered",
+			fields := append(fctx.Fields(req.Context()),
 				zap.Error(err),
 				zap.String("method", req.Method),
 				zap.String("path", c.Path()),
 				zap.String("uri", req.RequestURI),
-				zap.String("request_id", c.Response().Header().Get(echo.HeaderXRequestID)),
-				zap.String("trace_id", spanCtx.TraceID().String()),
-				zap.String("span_id", spanCtx.SpanID().String()),
 				zap.ByteString("stack", stack),
 			)
+			s.Logger.Error("panic recovered", fields...)
 			return err
 		},
 	}))

--- a/fastecho.go
+++ b/fastecho.go
@@ -39,8 +39,8 @@ import (
 	"github.com/ingka-group/fastecho/echozap"
 	"github.com/ingka-group/fastecho/env"
 	"github.com/ingka-group/fastecho/fctx"
-	"github.com/ingka-group/fastecho/telemetry"
 	"github.com/ingka-group/fastecho/router"
+	"github.com/ingka-group/fastecho/telemetry"
 )
 
 const (

--- a/fastecho.go
+++ b/fastecho.go
@@ -39,7 +39,7 @@ import (
 	"github.com/ingka-group/fastecho/echozap"
 	"github.com/ingka-group/fastecho/env"
 	"github.com/ingka-group/fastecho/fctx"
-	"github.com/ingka-group/fastecho/otel"
+	"github.com/ingka-group/fastecho/telemetry"
 	"github.com/ingka-group/fastecho/router"
 )
 
@@ -297,8 +297,8 @@ func (s *server) config(cfg *Config) error {
 // middlewares configures all the middlewares for Echo.
 func (s *server) middlewares(cfg *Config) {
 	if !cfg.Opts.Tracing.Skip {
-		s.Echo.Use(otel.Middleware(
-			otel.WithSkipper(func(ctx echo.Context) bool {
+		s.Echo.Use(telemetry.Middleware(
+			telemetry.WithSkipper(func(ctx echo.Context) bool {
 				return isSwaggerRoute(ctx) || isMetricsRoute(ctx) || isHealthRoute(ctx)
 			}),
 		))

--- a/fctx/fields.go
+++ b/fctx/fields.go
@@ -1,0 +1,55 @@
+// Copyright © 2026 Ingka Holding B.V. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fctx
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+)
+
+// Fields returns the correlation fields for ctx: trace_id and span_id (when a
+// valid span context is present) and request_id (when set). It is the one place
+// these IDs are built, so middleware, the recover handler, and worker seeds all
+// derive them the same way.
+//
+// These are discrete, indexable log fields (not the traceparent wire header) so the log backend can query by trace_id and link a line to its trace.
+func Fields(ctx context.Context) []zap.Field {
+	var fields []zap.Field
+
+	if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
+		fields = append(fields,
+			zap.String("trace_id", sc.TraceID().String()),
+			zap.String("span_id", sc.SpanID().String()),
+		)
+	}
+	if id := RequestID(ctx); id != "" {
+		fields = append(fields, zap.String("request_id", id))
+	}
+	return fields
+}
+
+// NewRequestID returns a fresh UUIDv4 request id. One format everywhere: HTTP
+// uses it as Echo's request-id Generator, workers via WithNewRequestID.
+func NewRequestID() string {
+	return uuid.New().String()
+}
+
+// WithNewRequestID generates a new request id and stores it in ctx.
+func WithNewRequestID(ctx context.Context) context.Context {
+	return WithRequestID(ctx, NewRequestID())
+}

--- a/fctx/fields_test.go
+++ b/fctx/fields_test.go
@@ -1,0 +1,51 @@
+package fctx_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/ingka-group/fastecho/fctx"
+)
+
+func TestFields_WithSpanAndRequestID(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	ctx, span := tp.Tracer("test").Start(t.Context(), "s")
+	defer span.End()
+	ctx = fctx.WithRequestID(ctx, "req-123")
+
+	m := fieldMap(fctx.Fields(ctx))
+	assert.Equal(t, span.SpanContext().TraceID().String(), m["trace_id"])
+	assert.Equal(t, span.SpanContext().SpanID().String(), m["span_id"])
+	assert.Equal(t, "req-123", m["request_id"])
+}
+
+func TestFields_NoSpan_NoTraceFields(t *testing.T) {
+	m := fieldMap(fctx.Fields(t.Context()))
+	assert.NotContains(t, m, "trace_id")
+	assert.NotContains(t, m, "span_id")
+	assert.NotContains(t, m, "request_id")
+}
+
+func TestNewRequestID_IsUUIDv4(t *testing.T) {
+	id := fctx.NewRequestID()
+	require.Len(t, id, 36)
+	assert.Equal(t, byte('4'), id[14], "version nibble is 4")
+}
+
+// fieldMap logs the fields through an observer and reads them back as a map.
+func fieldMap(fields []zap.Field) map[string]any {
+	core, logs := observer.New(zapcore.DebugLevel)
+	zap.New(core).Info("probe", fields...)
+	return logs.All()[0].ContextMap()
+}

--- a/fctx/middleware.go
+++ b/fctx/middleware.go
@@ -52,22 +52,11 @@ func Middleware(logger *zap.Logger, tracer trace.Tracer) echo.MiddlewareFunc {
 			req := ec.Request()
 			ctx := req.Context()
 
-			var fields []zap.Field
-
-			if spanCtx := trace.SpanContextFromContext(ctx); spanCtx.IsValid() {
-				fields = append(fields,
-					zap.String("trace_id", spanCtx.TraceID().String()),
-					zap.String("span_id", spanCtx.SpanID().String()),
-				)
-			}
-
 			if reqID := ec.Response().Header().Get(echo.HeaderXRequestID); reqID != "" {
-				fields = append(fields, zap.String("request_id", reqID))
 				ctx = WithRequestID(ctx, reqID)
 			}
 
-			ctx = WithLogger(ctx, logger.With(fields...))
-
+			ctx = WithLogger(ctx, logger.With(Fields(ctx)...))
 			if tracer != nil {
 				ctx = WithTracer(ctx, tracer)
 			}

--- a/telemetry/config.go
+++ b/telemetry/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package otel
+package telemetry
 
 import (
 	"github.com/labstack/echo/v4/middleware"

--- a/telemetry/middleware.go
+++ b/telemetry/middleware.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package otel
+package telemetry
 
 import (
 	"context"

--- a/telemetry/span.go
+++ b/telemetry/span.go
@@ -20,9 +20,10 @@ import (
 	"runtime"
 	"strings"
 
-	otelSDK "go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/ingka-group/fastecho/fctx"
 )
 
 // StartSpan starts a child span named after the calling function and returns
@@ -31,15 +32,14 @@ import (
 // The span name is auto-discovered from the caller using runtime.Caller,
 // formatted as package.Type.Method (e.g. "forecast.Service.Recompute").
 //
-// Uses the global TracerProvider. If tracing is not configured, returns a
-// no-op span (safe to defer .End()).
+// Uses the tracer from fctx.Tracer(ctx); falls back to a no-op tracer if none is set.
 //
 // For custom span names, use the standard OTel API directly:
 //
 //	tracer := otel.Tracer("my-scope")
 //	ctx, span := tracer.Start(ctx, "custom-name")
 func StartSpan(ctx context.Context, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-	return otelSDK.Tracer(ScopeName).Start(ctx, callerName(1), opts...)
+	return fctx.Tracer(ctx).Start(ctx, callerName(1), opts...)
 }
 
 // SpanFunc wraps a function call in a span with the given name. The span starts
@@ -47,14 +47,14 @@ func StartSpan(ctx context.Context, opts ...trace.SpanStartOption) (context.Cont
 // that don't accept context.Context:
 //
 //	var result T
-//	otel.SpanFunc(ctx, "heavy-algorithm", func() {
+//	telemetry.SpanFunc(ctx, "heavy-algorithm", func() {
 //	    result = computeHeavyAlgorithm(data)
 //	})
 //
 // If fn panics, the panic is recorded on the span and re-raised.
 // If tracing is not configured, fn is still called (no-op span).
 func SpanFunc(ctx context.Context, name string, fn func()) {
-	_, span := otelSDK.Tracer(ScopeName).Start(ctx, name)
+	_, span := fctx.Tracer(ctx).Start(ctx, name)
 	defer span.End()
 	defer func() {
 		if r := recover(); r != nil {

--- a/telemetry/span.go
+++ b/telemetry/span.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package otel
+package telemetry
 
 import (
 	"context"

--- a/telemetry/span_test.go
+++ b/telemetry/span_test.go
@@ -20,34 +20,26 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	otelSDK "go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	otelTrace "go.opentelemetry.io/otel/trace"
 
+	"github.com/ingka-group/fastecho/fctx"
 	"github.com/ingka-group/fastecho/telemetry"
 )
-
-func setGlobalTPForSpan(tp otelTrace.TracerProvider) otelTrace.TracerProvider {
-	prev := otelSDK.GetTracerProvider()
-	otelSDK.SetTracerProvider(tp)
-	return prev
-}
 
 func TestStartSpan(t *testing.T) {
 	exp := tracetest.NewInMemoryExporter()
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
 	defer func() { _ = tp.Shutdown(context.Background()) }()
 
-	prev := setGlobalTPForSpan(tp)
-	defer setGlobalTPForSpan(prev)
+	ctx := fctx.WithTracer(t.Context(), tp.Tracer("test"))
 
 	tests := map[string]struct {
 		ctx context.Context
 	}{
-		"creates span with global tracer": {
-			ctx: context.Background(),
+		"creates span with context tracer": {
+			ctx: ctx,
 		},
 	}
 
@@ -68,10 +60,9 @@ func TestStartSpan_AutoDiscoversCallerName(t *testing.T) {
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
 	defer func() { _ = tp.Shutdown(context.Background()) }()
 
-	prev := setGlobalTPForSpan(tp)
-	defer setGlobalTPForSpan(prev)
+	ctx := fctx.WithTracer(t.Context(), tp.Tracer("test"))
 
-	_, span := telemetry.StartSpan(context.Background())
+	_, span := telemetry.StartSpan(ctx)
 	span.End()
 
 	spans := exp.GetSpans()
@@ -84,11 +75,10 @@ func TestStartSpan_ChildAttachesToParent(t *testing.T) {
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
 	defer func() { _ = tp.Shutdown(context.Background()) }()
 
-	prev := setGlobalTPForSpan(tp)
-	defer setGlobalTPForSpan(prev)
+	ctx := fctx.WithTracer(t.Context(), tp.Tracer("test"))
 
 	tracer := tp.Tracer("test")
-	ctx, parent := tracer.Start(context.Background(), "parent")
+	ctx, parent := tracer.Start(ctx, "parent")
 
 	_, child := telemetry.StartSpan(ctx)
 	child.End()
@@ -105,8 +95,8 @@ func TestStartSpan_ChildAttachesToParent(t *testing.T) {
 	assert.Equal(t, parentSpan.SpanContext.SpanID(), childSpan.Parent.SpanID())
 }
 
-func TestStartSpan_NoopWhenNoGlobalTracer(t *testing.T) {
-	ctx, span := telemetry.StartSpan(context.Background())
+func TestStartSpan_NoopWhenNoContextTracer(t *testing.T) {
+	ctx, span := telemetry.StartSpan(t.Context())
 	defer span.End()
 
 	require.NotNil(t, ctx)
@@ -114,16 +104,30 @@ func TestStartSpan_NoopWhenNoGlobalTracer(t *testing.T) {
 	assert.NotPanics(t, func() { span.End() })
 }
 
+func TestStartSpan_UsesContextTracer(t *testing.T) {
+	// A per-context in-memory provider, with NO global set.
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	ctx := fctx.WithTracer(t.Context(), tp.Tracer("ctx-scope"))
+
+	_, span := telemetry.StartSpan(ctx)
+	span.End()
+
+	spans := exp.GetSpans()
+	require.Len(t, spans, 1, "span recorded on the context provider, not the global")
+}
+
 func TestSpanFunc(t *testing.T) {
 	exp := tracetest.NewInMemoryExporter()
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
 	defer func() { _ = tp.Shutdown(context.Background()) }()
 
-	prev := setGlobalTPForSpan(tp)
-	defer setGlobalTPForSpan(prev)
+	ctx := fctx.WithTracer(t.Context(), tp.Tracer("test"))
 
 	var called bool
-	telemetry.SpanFunc(context.Background(), "heavy-algorithm", func() {
+	telemetry.SpanFunc(ctx, "heavy-algorithm", func() {
 		called = true
 	})
 
@@ -139,11 +143,10 @@ func TestSpanFunc_ChildAttachesToParent(t *testing.T) {
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
 	defer func() { _ = tp.Shutdown(context.Background()) }()
 
-	prev := setGlobalTPForSpan(tp)
-	defer setGlobalTPForSpan(prev)
+	ctx := fctx.WithTracer(t.Context(), tp.Tracer("test"))
 
 	tracer := tp.Tracer("test")
-	ctx, parent := tracer.Start(context.Background(), "parent")
+	ctx, parent := tracer.Start(ctx, "parent")
 
 	telemetry.SpanFunc(ctx, "child-work", func() {})
 	parent.End()
@@ -154,10 +157,10 @@ func TestSpanFunc_ChildAttachesToParent(t *testing.T) {
 	assert.Equal(t, spans[1].SpanContext.SpanID(), spans[0].Parent.SpanID())
 }
 
-func TestSpanFunc_NoopWhenNoGlobalTracer(t *testing.T) {
+func TestSpanFunc_NoopWhenNoContextTracer(t *testing.T) {
 	var called bool
 	assert.NotPanics(t, func() {
-		telemetry.SpanFunc(context.Background(), "noop-work", func() {
+		telemetry.SpanFunc(t.Context(), "noop-work", func() {
 			called = true
 		})
 	})
@@ -169,11 +172,10 @@ func TestSpanFunc_RecordsPanicAndReraises(t *testing.T) {
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
 	defer func() { _ = tp.Shutdown(context.Background()) }()
 
-	prev := setGlobalTPForSpan(tp)
-	defer setGlobalTPForSpan(prev)
+	ctx := fctx.WithTracer(t.Context(), tp.Tracer("test"))
 
 	assert.PanicsWithValue(t, "something broke", func() {
-		telemetry.SpanFunc(context.Background(), "panicking-work", func() {
+		telemetry.SpanFunc(ctx, "panicking-work", func() {
 			panic("something broke")
 		})
 	})

--- a/telemetry/span_test.go
+++ b/telemetry/span_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package otel_test
+package telemetry_test
 
 import (
 	"context"
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	otelTrace "go.opentelemetry.io/otel/trace"
 
-	feotel "github.com/ingka-group/fastecho/otel"
+	"github.com/ingka-group/fastecho/telemetry"
 )
 
 func setGlobalTPForSpan(tp otelTrace.TracerProvider) otelTrace.TracerProvider {
@@ -53,7 +53,7 @@ func TestStartSpan(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx, span := feotel.StartSpan(tc.ctx)
+			ctx, span := telemetry.StartSpan(tc.ctx)
 			defer span.End()
 
 			require.NotNil(t, span)
@@ -71,7 +71,7 @@ func TestStartSpan_AutoDiscoversCallerName(t *testing.T) {
 	prev := setGlobalTPForSpan(tp)
 	defer setGlobalTPForSpan(prev)
 
-	_, span := feotel.StartSpan(context.Background())
+	_, span := telemetry.StartSpan(context.Background())
 	span.End()
 
 	spans := exp.GetSpans()
@@ -90,7 +90,7 @@ func TestStartSpan_ChildAttachesToParent(t *testing.T) {
 	tracer := tp.Tracer("test")
 	ctx, parent := tracer.Start(context.Background(), "parent")
 
-	_, child := feotel.StartSpan(ctx)
+	_, child := telemetry.StartSpan(ctx)
 	child.End()
 	parent.End()
 
@@ -106,7 +106,7 @@ func TestStartSpan_ChildAttachesToParent(t *testing.T) {
 }
 
 func TestStartSpan_NoopWhenNoGlobalTracer(t *testing.T) {
-	ctx, span := feotel.StartSpan(context.Background())
+	ctx, span := telemetry.StartSpan(context.Background())
 	defer span.End()
 
 	require.NotNil(t, ctx)
@@ -123,7 +123,7 @@ func TestSpanFunc(t *testing.T) {
 	defer setGlobalTPForSpan(prev)
 
 	var called bool
-	feotel.SpanFunc(context.Background(), "heavy-algorithm", func() {
+	telemetry.SpanFunc(context.Background(), "heavy-algorithm", func() {
 		called = true
 	})
 
@@ -145,7 +145,7 @@ func TestSpanFunc_ChildAttachesToParent(t *testing.T) {
 	tracer := tp.Tracer("test")
 	ctx, parent := tracer.Start(context.Background(), "parent")
 
-	feotel.SpanFunc(ctx, "child-work", func() {})
+	telemetry.SpanFunc(ctx, "child-work", func() {})
 	parent.End()
 
 	spans := exp.GetSpans()
@@ -157,7 +157,7 @@ func TestSpanFunc_ChildAttachesToParent(t *testing.T) {
 func TestSpanFunc_NoopWhenNoGlobalTracer(t *testing.T) {
 	var called bool
 	assert.NotPanics(t, func() {
-		feotel.SpanFunc(context.Background(), "noop-work", func() {
+		telemetry.SpanFunc(context.Background(), "noop-work", func() {
 			called = true
 		})
 	})
@@ -173,7 +173,7 @@ func TestSpanFunc_RecordsPanicAndReraises(t *testing.T) {
 	defer setGlobalTPForSpan(prev)
 
 	assert.PanicsWithValue(t, "something broke", func() {
-		feotel.SpanFunc(context.Background(), "panicking-work", func() {
+		telemetry.SpanFunc(context.Background(), "panicking-work", func() {
 			panic("something broke")
 		})
 	})


### PR DESCRIPTION
## Foundation (OTel-only release)

Foundational, low-risk layer moving fastecho's observability onto OpenTelemetry. No new dependencies. Merges to `main` first; subsequent branches build on it.

### What's in here (2 layers, 3 commits)

**L1 — `feat(fctx): add Fields + NewRequestID/WithNewRequestID`**
- `fctx.Fields(ctx) []zap.Field` — the single correlation-ID emission point: `trace_id`/`span_id` when the span context is valid, `request_id` when set.
- `fctx.NewRequestID()` (UUIDv4) and `fctx.WithNewRequestID(ctx)`.
- `fctx.Middleware`, Echo's request-id `Generator`, and the recover handler now build IDs through `fctx.Fields` (inline assembly removed; `uuid` import moved out of `fastecho.go` into `fctx`).

**L2 — `refactor(telemetry): rename otel package to telemetry`** + **`feat(telemetry): StartSpan/SpanFunc read the tracer from fctx.Tracer(ctx)`**
- Renamed the local `otel` package → `telemetry` (it shadowed upstream `go.opentelemetry.io/otel`, forcing `otelSDK`/`feotel` aliases). It will also host the OTel bootstrap (`telemetry.Init`) in a follow-up.
- `StartSpan`/`SpanFunc` now resolve the tracer from `fctx.Tracer(ctx)` (no-op fallback) instead of the global — making `fctx.WithTracer` meaningful and letting multiple providers/tests coexist. Behaviour is unchanged under a single global provider (the middleware stores that same tracer in ctx).

### ⚠️ Breaking for consumers
- Import path `github.com/ingka-group/fastecho/otel` → `…/telemetry`; call sites `otel.StartSpan`/`otel.SpanFunc`/`otel.Middleware`/`otel.WithSkipper` → `telemetry.*`. (Full migration notes ship with the docs follow-up.)

### Verification
- `make pre-commit`, `go build ./...`, `go vet ./...`, `go test ./...` all green.
- TDD throughout; per-task + whole-branch review clean (no Critical/Important findings).
