### PR TITLE
feat(echozap): access-log correlation fields + lowercase levels

### DIFF
--- a/config.go
+++ b/config.go
@@ -40,25 +40,31 @@ type Config struct {
 
 // Opts define configuration options for fastecho.
 type Opts struct {
-	Metrics      MetricsOpts      `json:"metrics"`
-	Tracing      TracingOpts      `json:"tracing"`
-	HealthChecks HealthChecksOpts `json:"health_checks"`
+	Metrics      MetricsOpts
+	Tracing      TracingOpts
+	Logs         LogsOpts
+	HealthChecks HealthChecksOpts
 }
 
 // MetricsOpts define configuration options for metrics.
 type MetricsOpts struct {
-	Skip bool `json:"skip"`
+	Skip bool
 }
 
 // TracingOpts define configuration options for tracing.
 type TracingOpts struct {
-	Skip bool `json:"skip"`
+	Skip bool
+}
+
+// LogsOpts define configuration options for logging.
+type LogsOpts struct {
+	Skip bool // disable the access-log middleware entirely
 }
 
 // HealthChecksOpts define configuration options for health checks.
 type HealthChecksOpts struct {
-	Skip bool     `json:"skip"`
-	DB   *gorm.DB `json:"db,omitempty"`
+	Skip bool
+	DB   *gorm.DB
 }
 
 type Plugin struct {

--- a/echozap/logger.go
+++ b/echozap/logger.go
@@ -52,8 +52,11 @@ func New() (*zap.Logger, error) {
 	// Override log level based on fastecho logic above
 	config.Level = zap.NewAtomicLevelAt(ZapLevel(level))
 
-	// Use CapitalLevelEncoder in all envs
-	config.EncoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
+	// A log backend color-codes lines by a lowercase `level` value
+	// (trace/debug/info/warn/error/fatal). Pipelines that promote the JSON
+	// `level` field to a label match on lowercase; "INFO" is unrecognised and
+	// renders uncoloured.
+	config.EncoderConfig.EncodeLevel = zapcore.LowercaseLevelEncoder
 
 	// Use human-readable timestamp
 	config.EncoderConfig.EncodeTime = zapcore.RFC3339TimeEncoder

--- a/echozap/middleware.go
+++ b/echozap/middleware.go
@@ -21,6 +21,8 @@ import (
 	"github.com/labstack/echo/v4"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/ingka-group/fastecho/fctx"
 )
 
 type (
@@ -75,10 +77,7 @@ func ZapLoggerMiddlewareWithConfig(log *zap.Logger, config ZapLoggerMiddlewareCo
 			req := c.Request()
 			res := c.Response()
 
-			id := req.Header.Get(echo.HeaderXRequestID)
-			if id == "" {
-				id = res.Header().Get(echo.HeaderXRequestID)
-			}
+			logger := log.With(fctx.Fields(c.Request().Context())...)
 
 			fields := []zapcore.Field{
 				zap.String("remote_ip", c.RealIP()),
@@ -88,17 +87,16 @@ func ZapLoggerMiddlewareWithConfig(log *zap.Logger, config ZapLoggerMiddlewareCo
 				zap.Int("status", res.Status),
 				zap.Int64("size", res.Size),
 				zap.String("user_agent", req.UserAgent()),
-				zap.String("request_id", id),
 			}
 
 			n := res.Status
 			switch {
 			case n >= 500:
-				log.With(zap.Error(err)).Error("Server error", fields...)
+				logger.With(zap.Error(err)).Error("Server error", fields...)
 			case n >= 400:
-				log.With(zap.Error(err)).Warn("Client error", fields...)
+				logger.With(zap.Error(err)).Warn("Client error", fields...)
 			case n >= 300:
-				log.Info("Redirection", fields...)
+				logger.Info("Redirection", fields...)
 			default:
 				// noop: don't log successful requests
 			}

--- a/echozap/middleware_test.go
+++ b/echozap/middleware_test.go
@@ -107,7 +107,7 @@ func TestAccessLog_5xxCarriesTraceIDAndError(t *testing.T) {
 	e.GET("/x", func(c echo.Context) error { return echo.NewHTTPError(500, "boom") })
 
 	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+	e.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/x", nil))
 
 	require.Equal(t, 1, logs.Len(), "5xx still logged (regression guard)")
 	got := logs.All()[0]
@@ -130,7 +130,7 @@ func TestAccessLog_4xxCarriesRequestID(t *testing.T) {
 	e.GET("/x", func(c echo.Context) error { return c.String(400, "bad") })
 
 	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+	e.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/x", nil))
 
 	require.Equal(t, 1, logs.Len())
 	assert.Equal(t, "Client error", logs.All()[0].Message)
@@ -144,7 +144,7 @@ func TestAccessLog_2xxNotLogged(t *testing.T) {
 	e.GET("/x", func(c echo.Context) error { return c.String(200, "ok") })
 
 	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+	e.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/x", nil))
 
 	assert.Equal(t, 0, logs.Len(), "2xx not logged")
 }

--- a/echozap/middleware_test.go
+++ b/echozap/middleware_test.go
@@ -22,8 +22,13 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	trace "go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/ingka-group/fastecho/fctx"
 )
 
 func TestZapLoggerMiddleware(t *testing.T) {
@@ -77,4 +82,69 @@ func TestZapLoggerMiddlewareWithConfig(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, 0, logs.Len())
+}
+
+func TestAccessLog_5xxCarriesTraceIDAndError(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    trace.TraceID{0x01},
+		SpanID:     trace.SpanID{0x01},
+		TraceFlags: trace.FlagsSampled,
+	})
+
+	e := echo.New()
+	// Seed a span context, as otelecho would, so Fields(ctx) yields trace_id.
+	e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			ctx := trace.ContextWithSpanContext(c.Request().Context(), sc)
+			c.SetRequest(c.Request().WithContext(ctx))
+			return next(c)
+		}
+	})
+	e.Use(ZapLoggerMiddlewareWithConfig(zap.New(core), ZapLoggerMiddlewareConfig{}))
+	// Return an error so the access log captures it (zap.Error).
+	e.GET("/x", func(c echo.Context) error { return echo.NewHTTPError(500, "boom") })
+
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+
+	require.Equal(t, 1, logs.Len(), "5xx still logged (regression guard)")
+	got := logs.All()[0]
+	assert.Equal(t, "Server error", got.Message)
+	assert.Equal(t, sc.TraceID().String(), got.ContextMap()["trace_id"], "5xx line carries trace_id")
+	assert.Contains(t, got.ContextMap(), "error", "5xx line carries the error string")
+}
+
+func TestAccessLog_4xxCarriesRequestID(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	e := echo.New()
+	e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			ctx := fctx.WithRequestID(c.Request().Context(), "req-1")
+			c.SetRequest(c.Request().WithContext(ctx))
+			return next(c)
+		}
+	})
+	e.Use(ZapLoggerMiddlewareWithConfig(zap.New(core), ZapLoggerMiddlewareConfig{}))
+	e.GET("/x", func(c echo.Context) error { return c.String(400, "bad") })
+
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+
+	require.Equal(t, 1, logs.Len())
+	assert.Equal(t, "Client error", logs.All()[0].Message)
+	assert.Equal(t, "req-1", logs.All()[0].ContextMap()["request_id"])
+}
+
+func TestAccessLog_2xxNotLogged(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	e := echo.New()
+	e.Use(ZapLoggerMiddlewareWithConfig(zap.New(core), ZapLoggerMiddlewareConfig{}))
+	e.GET("/x", func(c echo.Context) error { return c.String(200, "ok") })
+
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+
+	assert.Equal(t, 0, logs.Len(), "2xx not logged")
 }

--- a/fastecho.go
+++ b/fastecho.go
@@ -349,9 +349,11 @@ func (s *server) middlewares(cfg *Config) {
 	}))
 
 	// 6. Access log, innermost: sees the final status via the request logger.
-	s.Echo.Use(echozap.ZapLoggerMiddlewareWithConfig(s.Logger, echozap.ZapLoggerMiddlewareConfig{
-		Skipper: skip,
-	}))
+	if !cfg.Opts.Logs.Skip {
+		s.Echo.Use(echozap.ZapLoggerMiddlewareWithConfig(s.Logger, echozap.ZapLoggerMiddlewareConfig{
+			Skipper: skip,
+		}))
+	}
 }
 
 // run starts the server and listens for interrupt signals to gracefully shut it down.


### PR DESCRIPTION
## Access log — correlation fields + lowercase levels

Stacked on `otel/server-telemetry` (base of this PR).

- Logged access lines (3xx/4xx/5xx) now carry `trace_id`/`span_id`/`request_id`, derived from `fctx.Fields(ctx)` on the configured logger (same pattern as the recover handler, not `fctx.Logger`). 2xx stays unlogged.
- **Keeps the 5xx error string** (the dedicated error handler that will own it is out of scope for this release), so a 5xx line carries the error *and* the trace id.
- Log level encoder switched to lowercase (`"level":"info"`, was `"INFO"`) so a log backend can color-code / promote `level` to a label.
- New `Opts.Logs.Skip` toggle disables the access-log middleware entirely. Dropped the dead `json` tags from the `Opts` family (never (un)marshalled).

### ⚠️ Breaking
- Log level field is now lowercase — update any filter/alert matching uppercase `INFO`/`WARN`/`ERROR`. (Migration note ships with the docs PR.)

### Verification
- `make pre-commit`, `go build ./...`, `go test ./...` all green. TDD; per-task review clean (no Critical/Important).
