### PR TITLE
feat(worker): name-keyed Workers map + seeded context + failure metric

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,9 +33,9 @@ type Config struct {
 	Plugins      []Plugin
 	EchoFn       func(e *echo.Echo) error
 	// Workers are long-running background processes managed by fastecho's
-	// lifecycle. Each is started in its own goroutine and receives a context
-	// that is cancelled on shutdown.
-	Workers []Worker
+	// lifecycle, keyed by name. Each runs in its own goroutine with a context that
+	// is cancelled on shutdown; its logs/spans are tagged worker=<name>.
+	Workers map[string]Worker
 }
 
 // Opts define configuration options for fastecho.

--- a/fastecho.go
+++ b/fastecho.go
@@ -31,6 +31,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho"
+	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
 
 	"github.com/ingka-group/fastecho/echozap"
@@ -84,12 +85,13 @@ type server struct {
 	Router    *router.Router
 	Logger    *zap.Logger
 	Providers *telemetry.Providers
-	Workers   []Worker
+	Workers   map[string]Worker
 
 	workerInitialRestartDelay  time.Duration
 	workerMaxRestartDelay      time.Duration
 	workerStableResetThreshold time.Duration
 	workerCrashLoopThreshold   int
+	workerFailures             metric.Int64Counter
 }
 
 type FastEcho struct {
@@ -381,10 +383,19 @@ func (s *server) serve(ctx context.Context, host string, port string) error {
 	// Flush buffered logs on the way out
 	defer func() { _ = s.Logger.Sync() }()
 
+	// One counter for all workers; labelled per worker/kind at record time.
+	// MeterProvider is always non-nil (noop when metrics are skipped → Add is a
+	// no-op), so this is safe to create unconditionally.
+	s.workerFailures, _ = s.Providers.MeterProvider.Meter(telemetry.ScopeName).Int64Counter(
+		"fastecho.worker.failures",
+		metric.WithDescription("background worker panics and error exits"),
+		metric.WithUnit("{failure}"),
+	)
+
 	// Start background workers, tracked so shutdown can wait for them to drain.
 	var workers sync.WaitGroup
-	for _, w := range s.Workers {
-		workers.Go(func() { s.runWorker(ctx, w) })
+	for name, w := range s.Workers {
+		workers.Go(func() { s.runWorker(ctx, name, w) })
 	}
 
 	// Start server

--- a/worker.go
+++ b/worker.go
@@ -21,6 +21,9 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/ingka-group/fastecho/fctx"
@@ -34,12 +37,12 @@ type Worker func(ctx context.Context) error
 // runWorker supervises a worker for the lifetime of ctx, restarting it with
 // capped exponential backoff on any early return so a crashed worker is never
 // left silently dead until shutdown. It exits only when ctx is cancelled.
-func (s *server) runWorker(ctx context.Context, w Worker) {
+func (s *server) runWorker(ctx context.Context, name string, w Worker) {
 	delay := s.workerInitialRestartDelay
 	failures := 0
 	for {
 		start := time.Now()
-		s.runWorkerOnce(ctx, w)
+		s.runWorkerOnce(ctx, name, w)
 		if ctx.Err() != nil {
 			return
 		}
@@ -63,6 +66,7 @@ func (s *server) runWorker(ctx context.Context, w Worker) {
 			logRestart = s.Logger.Error
 		}
 		logRestart("restarting worker",
+			zap.String("worker", name),
 			zap.Duration("backoff", delay),
 			zap.Int("failures", failures),
 		)
@@ -72,13 +76,24 @@ func (s *server) runWorker(ctx context.Context, w Worker) {
 
 // runWorkerOnce runs a worker exactly once, recovering panics and logging any
 // error so that one worker cannot crash the process or affect the others.
-func (s *server) runWorkerOnce(ctx context.Context, w Worker) {
-	ctx = fctx.WithLogger(ctx, s.Logger)
-	ctx = fctx.WithTracer(ctx, s.Providers.TracerProvider.Tracer(telemetry.ScopeName))
+func (s *server) runWorkerOnce(ctx context.Context, name string, w Worker) {
+	ctx = fctx.WithLogger(ctx, s.Logger.With(zap.String("worker", name)))
+	// Seed a tracer that stamps worker=<name> on every span it starts, so the
+	// worker's spans are filterable by worker - they're roots (no inbound HTTP
+	// request), so this label is how you find all runs of a given worker. (This
+	// is exactly what the ctx-scoped tracer buys us: a per-context tracer the
+	// global can't express.) Providers is always non-nil; noop tracer when skipped.
+	ctx = fctx.WithTracer(ctx, workerTracer{
+		Tracer: s.Providers.TracerProvider.Tracer(telemetry.ScopeName),
+		attrs:  []attribute.KeyValue{attribute.String("worker", name)},
+	})
+	// Fresh request id per run, so each restart's logs/spans correlate to that run.
+	ctx = fctx.WithNewRequestID(ctx)
 
 	defer func() {
 		if r := recover(); r != nil {
-			s.Logger.Error("worker panic recovered",
+			s.recordWorkerFailure(ctx, name, "panic")
+			fctx.Logger(ctx).Error("worker panic recovered",
 				zap.Any("panic", r),
 				zap.ByteString("stack", debug.Stack()),
 			)
@@ -87,8 +102,40 @@ func (s *server) runWorkerOnce(ctx context.Context, w Worker) {
 
 	// A cancelled context is the expected shutdown signal, not an error.
 	if err := w(ctx); err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-		s.Logger.Error("worker exited with error", zap.Error(err))
+		s.recordWorkerFailure(ctx, name, "error")
+		fctx.Logger(ctx).Error("worker exited with error", zap.Error(err))
 	}
+}
+
+// recordWorkerFailure increments the worker-failure counter, labelled by worker
+// and kind (panic|error), so failures are alertable per worker, e.g.
+// rate(fastecho_worker_failures_total{worker="..."}[5m]) > 0. Only fastecho can
+// see these (they happen in runWorkerOnce), so it's a framework-owned metric -
+// like otelecho's HTTP metrics, not a consumer helper. Nil-safe: the counter is
+// created on the Run path (serve); direct runWorkerOnce unit tests may leave it unset.
+func (s *server) recordWorkerFailure(ctx context.Context, name, kind string) {
+	if s.workerFailures == nil {
+		return
+	}
+	s.workerFailures.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("worker", name),
+		attribute.String("kind", kind),
+	))
+}
+
+// workerTracer wraps a tracer so every span it starts carries the worker's name
+// as an attribute. Worker spans have no inbound-request parent, so labelling them
+// is how you find all runs of one worker in the trace backend. Note: we do NOT
+// span the whole worker run - workers are long-lived (block until shutdown), so a
+// run-spanning span would stay open for the service lifetime and never export.
+// The worker body spans each unit of work; this tracer just labels those spans.
+type workerTracer struct {
+	trace.Tracer
+	attrs []attribute.KeyValue
+}
+
+func (t workerTracer) Start(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	return t.Tracer.Start(ctx, name, append(opts, trace.WithAttributes(t.attrs...))...)
 }
 
 // drainWorkers waits for all workers to return, bounded by ctx. If they do not

--- a/worker_test.go
+++ b/worker_test.go
@@ -28,8 +28,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metricnoop "go.opentelemetry.io/otel/metric/noop"
-	"go.opentelemetry.io/otel/trace"
-	"go.opentelemetry.io/otel/trace/embedded"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	tracenoop "go.opentelemetry.io/otel/trace/noop"
 	"go.uber.org/goleak"
 	"go.uber.org/zap"
@@ -61,8 +63,8 @@ func TestServeCancelsWorkerContextOnShutdown(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	s := newTestServer()
 	cancelled := make(chan struct{})
-	s.Workers = []Worker{
-		func(ctx context.Context) error {
+	s.Workers = map[string]Worker{
+		"cancel-worker": func(ctx context.Context) error {
 			<-ctx.Done()
 			close(cancelled)
 			return ctx.Err()
@@ -93,8 +95,8 @@ func TestServeWaitsForWorkersOnShutdown(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	s := newTestServer()
 	var drained atomic.Bool
-	s.Workers = []Worker{
-		func(ctx context.Context) error {
+	s.Workers = map[string]Worker{
+		"drain-worker": func(ctx context.Context) error {
 			<-ctx.Done()
 			time.Sleep(100 * time.Millisecond)
 			drained.Store(true)
@@ -121,14 +123,14 @@ func TestServeSurvivesFailingWorkers(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	s := newTestServer()
 	healthy := make(chan struct{})
-	s.Workers = []Worker{
-		func(ctx context.Context) error {
+	s.Workers = map[string]Worker{
+		"error-worker": func(ctx context.Context) error {
 			return errors.New("boom")
 		},
-		func(ctx context.Context) error {
+		"panic-worker": func(ctx context.Context) error {
 			panic("kaboom")
 		},
-		func(ctx context.Context) error {
+		"healthy-worker": func(ctx context.Context) error {
 			close(healthy)
 			<-ctx.Done()
 			return nil
@@ -190,7 +192,7 @@ func TestRunWorkerOnce(t *testing.T) {
 			s, logs := newObserverServer()
 
 			assert.NotPanics(t, func() {
-				s.runWorkerOnce(context.Background(), tt.worker)
+				s.runWorkerOnce(context.Background(), "test-worker", tt.worker)
 			})
 
 			if tt.wantMessage == "" {
@@ -208,24 +210,10 @@ func TestRunWorkerOnce(t *testing.T) {
 	}
 }
 
-type stubTracer struct{ embedded.Tracer }
-
-func (stubTracer) Start(ctx context.Context, _ string, _ ...trace.SpanStartOption) (context.Context, trace.Span) {
-	return ctx, nil
-}
-
-// stubTracerProvider hands out stubTracer so the worker-seed test can assert
-// runWorkerOnce sources its tracer from s.Providers.TracerProvider.
-type stubTracerProvider struct{ embedded.TracerProvider }
-
-func (stubTracerProvider) Tracer(_ string, _ ...trace.TracerOption) trace.Tracer {
-	return stubTracer{}
-}
-
 func TestRunWorkerInjectsLogger(t *testing.T) {
 	s, logs := newObserverServer()
 
-	s.runWorkerOnce(context.Background(), func(ctx context.Context) error {
+	s.runWorkerOnce(context.Background(), "log-worker", func(ctx context.Context) error {
 		fctx.Logger(ctx).Info("from worker")
 		return nil
 	})
@@ -234,18 +222,75 @@ func TestRunWorkerInjectsLogger(t *testing.T) {
 		"worker context should carry the server logger, not the no-op fallback")
 }
 
-func TestRunWorkerInjectsTracer(t *testing.T) {
-	s, _ := newObserverServer()
-	s.Providers = &telemetry.Providers{TracerProvider: stubTracerProvider{}}
+func TestRunWorkerOnce_SeedsContext(t *testing.T) {
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
 
-	var got trace.Tracer
-	s.runWorkerOnce(context.Background(), func(ctx context.Context) error {
-		got = fctx.Tracer(ctx)
+	core, logs := observer.New(zapcore.DebugLevel)
+	s := &server{
+		Logger:    zap.New(core),
+		Providers: &telemetry.Providers{TracerProvider: tp},
+	}
+
+	var gotReqID string
+	s.runWorkerOnce(t.Context(), "widget-worker", func(ctx context.Context) error {
+		gotReqID = fctx.RequestID(ctx)
+		_, span := fctx.Tracer(ctx).Start(ctx, "iteration")
+		fctx.Logger(ctx).Info("working")
+		span.End()
 		return nil
 	})
 
-	assert.IsType(t, stubTracer{}, got,
-		"worker context should carry the tracer from s.Providers.TracerProvider, not the no-op fallback")
+	assert.NotEmpty(t, gotReqID, "worker request id seeded")
+	// Don't assert the logger/tracer by identity comparison (zap.NewNop() returns
+	// a fresh pointer and fctx.Tracer never returns nil, so both would trivially
+	// pass). Their effect is the real proof: the span below was exported on the
+	// seeded provider, it carries worker=<name>, and the log line carries worker.
+	require.Len(t, rec.Ended(), 1, "worker span exported (tracer seeded, non-noop)")
+	spanAttrs := map[string]string{}
+	for _, kv := range rec.Ended()[0].Attributes() {
+		spanAttrs[string(kv.Key)] = kv.Value.AsString()
+	}
+	assert.Equal(t, "widget-worker", spanAttrs["worker"], "worker spans carry worker=<name>")
+	require.Equal(t, 1, logs.FilterMessage("working").Len())
+	assert.Equal(t, "widget-worker", logs.All()[0].ContextMap()["worker"])
+}
+
+func TestRunWorkerOnce_RecordsFailureMetric(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	failures, err := mp.Meter(telemetry.ScopeName).Int64Counter("fastecho.worker.failures")
+	require.NoError(t, err)
+
+	s := &server{
+		Logger:         zap.NewNop(),
+		Providers:      &telemetry.Providers{TracerProvider: tracenoop.NewTracerProvider()},
+		workerFailures: failures,
+	}
+	s.runWorkerOnce(t.Context(), "widget-worker", func(ctx context.Context) error {
+		return errors.New("boom")
+	})
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	var got int64
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "fastecho.worker.failures" {
+				continue
+			}
+			for _, dp := range m.Data.(metricdata.Sum[int64]).DataPoints {
+				w, _ := dp.Attributes.Value("worker")
+				k, _ := dp.Attributes.Value("kind")
+				if w.AsString() == "widget-worker" && k.AsString() == "error" {
+					got += dp.Value
+				}
+			}
+		}
+	}
+	assert.Equal(t, int64(1), got, "error-exit bumps the worker failure counter, labelled worker+kind")
 }
 
 func TestRunWorkerRestartsAfterFailuresThenStabilizes(t *testing.T) {
@@ -255,7 +300,7 @@ func TestRunWorkerRestartsAfterFailuresThenStabilizes(t *testing.T) {
 		healthy := make(chan struct{})
 		ctx, cancel := context.WithCancel(context.Background())
 
-		go s.runWorker(ctx, func(ctx context.Context) error {
+		go s.runWorker(ctx, "test-worker", func(ctx context.Context) error {
 			if calls.Add(1) < 3 {
 				return errors.New("boom")
 			}
@@ -281,7 +326,7 @@ func TestRunWorkerRestartsAfterPanic(t *testing.T) {
 		healthy := make(chan struct{})
 		ctx, cancel := context.WithCancel(context.Background())
 
-		go s.runWorker(ctx, func(ctx context.Context) error {
+		go s.runWorker(ctx, "test-worker", func(ctx context.Context) error {
 			if calls.Add(1) == 1 {
 				panic("kaboom")
 			}
@@ -307,7 +352,7 @@ func TestRunWorkerRestartsAfterCleanReturn(t *testing.T) {
 		healthy := make(chan struct{})
 		ctx, cancel := context.WithCancel(context.Background())
 
-		go s.runWorker(ctx, func(ctx context.Context) error {
+		go s.runWorker(ctx, "test-worker", func(ctx context.Context) error {
 			if calls.Add(1) == 1 {
 				return nil
 			}
@@ -334,7 +379,7 @@ func TestRunWorkerStopsOnContextCancel(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 
 		go func() {
-			s.runWorker(ctx, func(ctx context.Context) error {
+			s.runWorker(ctx, "test-worker", func(ctx context.Context) error {
 				close(running)
 				<-ctx.Done()
 				return ctx.Err()
@@ -363,7 +408,7 @@ func TestRunWorkerCancelDuringBackoffReturnsPromptly(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 
 		go func() {
-			s.runWorker(ctx, func(ctx context.Context) error {
+			s.runWorker(ctx, "test-worker", func(ctx context.Context) error {
 				calls.Add(1)
 				close(failed)
 				return errors.New("boom")
@@ -391,7 +436,7 @@ func TestRunWorkerResetsBackoffAfterStableRun(t *testing.T) {
 		healthy := make(chan struct{})
 		ctx, cancel := context.WithCancel(context.Background())
 
-		go s.runWorker(ctx, func(ctx context.Context) error {
+		go s.runWorker(ctx, "test-worker", func(ctx context.Context) error {
 			switch calls.Add(1) {
 			case 1:
 				return errors.New("boom")
@@ -426,7 +471,7 @@ func TestRunWorkerEscalatesLogAfterCrashLoopThreshold(t *testing.T) {
 		healthy := make(chan struct{})
 		ctx, cancel := context.WithCancel(context.Background())
 
-		go s.runWorker(ctx, func(ctx context.Context) error {
+		go s.runWorker(ctx, "test-worker", func(ctx context.Context) error {
 			if calls.Add(1) <= 3 {
 				return errors.New("boom")
 			}


### PR DESCRIPTION
## Worker telemetry — name-keyed workers, seeded context, failure metric

Stacked on `otel/access-log` (base of this PR). Layers worker observability on top of the PR #99 restart/backoff supervisor (which is preserved, not flattened).

- **`Config.Workers` is now `map[string]Worker`** (was `[]Worker`); the map key is the worker name. `Worker` stays `func(ctx context.Context) error`.
- Each run's context (in `runWorkerOnce`) is seeded with a logger labelled `worker=<name>`, a tracer that stamps `worker=<name>` on every span the body starts (workers are long-lived, so we label per-unit-of-work spans rather than span the whole run), and a fresh per-run request id (so each restart correlates to its own run).
- New metric `fastecho.worker.failures{worker,kind}` (`kind=panic|error`) for alertable worker failures. Normal/`ctx`-cancelled exits don't count.
- The supervision loop, backoff tuning, and `drainWorkers` are unchanged apart from threading the worker name through.

### ⚠️ Breaking
- `Config.Workers: []Worker{fn}` → `map[string]Worker{"my-worker": fn}`. (Migration note ships with the docs PR.)

### Verification
- `make pre-commit`, `go build ./...`, `go test ./...` all green. TDD; per-task review clean (no Critical/Important).
