### PR TITLE
feat(telemetry): WrapClient/WrapTransport propagate traceparent + X-Request-Id

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/swaggest/swgui v1.8.7
 	go.opentelemetry.io/contrib/exporters/autoexport v0.69.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.69.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.66.0
@@ -32,6 +33,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
+github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -113,6 +115,8 @@ go.opentelemetry.io/contrib/exporters/autoexport v0.69.0 h1:R3jsCoTIzv0BiYNhW0ax
 go.opentelemetry.io/contrib/exporters/autoexport v0.69.0/go.mod h1:m07gqyr2QhQxKOKb5vqKCCBtLH3uqlNYR7PU/FISXVU=
 go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.69.0 h1:p2oor9jp8aT5uqVuN9p0GCntXn5VX8qXdOH098hgLu4=
 go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.69.0/go.mod h1:NOiuETZRg7aNSNFPWqf4dAszhyFMVdKYXW4V0/DtbNA=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 h1:8tvICD4vSTOOsNrsI4Ljf6C+6UKvpTEH5XY3JMoyPoo=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0/go.mod h1:z9+yiacE0IHRqM4qFfkbt/JYlmYXgss8GY/jXoNuPJI=
 go.opentelemetry.io/contrib/instrumentation/runtime v0.69.0 h1:MtkMsuRo3zEXTTMALfyrszwCDZTkB6wolyPjbwFAdq0=
 go.opentelemetry.io/contrib/instrumentation/runtime v0.69.0/go.mod h1:FYTxnpsm+UPD0erZNq20GvnM8T2YQHiHtT2vokdpoac=
 go.opentelemetry.io/contrib/propagators/b3 v1.44.0 h1:1IFH4oFKK8KupzIelCl3u+bkxpGRps1oWRjQI2+TTWs=

--- a/telemetry/httpclient.go
+++ b/telemetry/httpclient.go
@@ -1,0 +1,68 @@
+// Copyright © 2026 Ingka Holding B.V. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// httpclient.go adds outbound HTTP propagation to the telemetry package: it
+// decorates an existing *http.Client / RoundTripper so a request carries its
+// inbound correlation onward - W3C traceparent (via otelhttp) and the
+// X-Request-Id from fctx - keeping a distributed trace unbroken across a service
+// hop instead of starting fresh on every outbound call. (Package doc lives in
+// telemetry.go.)
+package telemetry
+
+import (
+	"net/http"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
+	"github.com/ingka-group/fastecho/fctx"
+)
+
+// WrapClient augments c's transport so every request it sends propagates the
+// caller's trace context (traceparent, via otelhttp) and forwards
+// fctx.RequestID(ctx) as X-Request-Id. It mutates and returns c; a nil or
+// zero-value client is fine. Set the timeout, headers, etc. on c as usual -
+// this only decorates the transport.
+func WrapClient(c *http.Client) *http.Client {
+	if c == nil {
+		c = &http.Client{}
+	}
+	c.Transport = WrapTransport(c.Transport)
+	return c
+}
+
+// WrapTransport wraps base (nil → http.DefaultTransport) with trace-context
+// propagation and X-Request-Id forwarding. Use this when you hold a
+// RoundTripper directly (e.g. instrumenting a generated client).
+func WrapTransport(base http.RoundTripper) http.RoundTripper {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return requestIDTransport{base: otelhttp.NewTransport(base)}
+}
+
+type requestIDTransport struct {
+	base http.RoundTripper
+}
+
+func (t requestIDTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// The RoundTripper contract forbids mutating the caller's request; otelhttp
+	// (the wrapped base) also injects headers, so hand everything below a clone.
+	req = req.Clone(req.Context())
+
+	// Forward the request_id from the fctx context (plain header, not baggage).
+	if id := fctx.RequestID(req.Context()); id != "" && req.Header.Get("X-Request-Id") == "" {
+		req.Header.Set("X-Request-Id", id)
+	}
+	return t.base.RoundTrip(req)
+}

--- a/telemetry/httpclient_test.go
+++ b/telemetry/httpclient_test.go
@@ -37,6 +37,9 @@ import (
 func TestWrapClient_InjectsTraceparentAndRequestID(t *testing.T) {
 	// otelhttp injects via the global propagator, which defaults to a no-op;
 	// without this the traceparent assertion below fails (nothing is injected).
+	// Restore the prior propagator so this global mutation doesn't leak to other tests.
+	prevProp := otel.GetTextMapPropagator()
+	t.Cleanup(func() { otel.SetTextMapPropagator(prevProp) })
 	otel.SetTextMapPropagator(propagation.TraceContext{})
 
 	var gotTraceparent, gotRequestID string
@@ -73,6 +76,8 @@ func seedSpan(t *testing.T, ctx context.Context) context.Context {
 }
 
 func TestRoundTrip_PropagatesTraceAndRequestID(t *testing.T) {
+	prevProp := otel.GetTextMapPropagator()
+	t.Cleanup(func() { otel.SetTextMapPropagator(prevProp) })
 	otel.SetTextMapPropagator(propagation.TraceContext{})
 	tp := sdktrace.NewTracerProvider()
 	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })

--- a/telemetry/httpclient_test.go
+++ b/telemetry/httpclient_test.go
@@ -1,0 +1,107 @@
+// Copyright © 2026 Ingka Holding B.V. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/ingka-group/fastecho/fctx"
+	"github.com/ingka-group/fastecho/telemetry"
+)
+
+func TestWrapClient_InjectsTraceparentAndRequestID(t *testing.T) {
+	// otelhttp injects via the global propagator, which defaults to a no-op;
+	// without this the traceparent assertion below fails (nothing is injected).
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	var gotTraceparent, gotRequestID string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTraceparent = r.Header.Get("traceparent")
+		gotRequestID = r.Header.Get("X-Request-Id")
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	// Caller brings a normal client; WrapClient only augments its transport.
+	client := telemetry.WrapClient(&http.Client{})
+
+	ctx := fctx.WithRequestID(t.Context(), "req-xyz")
+	// Start a span so there is a traceparent to inject.
+	ctx = seedSpan(t, ctx)
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	assert.NotEmpty(t, gotTraceparent, "traceparent injected")
+	assert.Equal(t, "req-xyz", gotRequestID, "X-Request-Id forwarded from fctx")
+}
+
+func seedSpan(t *testing.T, ctx context.Context) context.Context {
+	t.Helper()
+	tp := sdktrace.NewTracerProvider()
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	ctx, span := tp.Tracer("test").Start(ctx, "client-call")
+	t.Cleanup(func() { span.End() })
+	return ctx
+}
+
+func TestRoundTrip_PropagatesTraceAndRequestID(t *testing.T) {
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	tp := sdktrace.NewTracerProvider()
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	// Downstream fastecho-like server: otelecho continues the inbound trace and
+	// echoes the request id + the trace id it saw.
+	e := echo.New()
+	e.Use(otelecho.Middleware("downstream", otelecho.WithTracerProvider(tp)))
+	e.GET("/echo", func(c echo.Context) error {
+		sc := trace.SpanContextFromContext(c.Request().Context())
+		return c.JSON(200, map[string]string{
+			"request_id": c.Request().Header.Get("X-Request-Id"),
+			"trace_id":   sc.TraceID().String(),
+		})
+	})
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	ctx, span := tp.Tracer("caller").Start(t.Context(), "outbound")
+	defer span.End()
+	ctx = fctx.WithRequestID(ctx, "rid-roundtrip")
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/echo", nil)
+	resp, err := telemetry.WrapClient(&http.Client{}).Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	var got map[string]string
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+	assert.Equal(t, "rid-roundtrip", got["request_id"], "X-Request-Id forwarded")
+	assert.Equal(t, span.SpanContext().TraceID().String(), got["trace_id"], "trace continued across the hop")
+}


### PR DESCRIPTION
## Outbound telemetry client — WrapClient / WrapTransport

Stacked on `otel/worker-telemetry` (base of this PR). Independent of the server layers — only needs `fctx.RequestID` + `otelhttp`.

- `telemetry.WrapClient(c *http.Client) *http.Client` augments an existing client's transport in place (nil/zero-value client is fine) so every request it sends propagates the caller's trace context (`traceparent`, via otelhttp) and forwards `fctx.RequestID(ctx)` as `X-Request-Id`.
- `telemetry.WrapTransport(base http.RoundTripper) http.RoundTripper` does the same for a bare RoundTripper (nil → `http.DefaultTransport`) — e.g. instrumenting a generated client.
- Wrap-the-client (dd-trace-go style), **not** a factory: the caller keeps a normal `*http.Client` and owns the URL, timeout, redirect policy, and headers. No factory/options/`WithBaseURL`/typed verbs.
- The inner `requestIDTransport` clones the request before mutating headers (RoundTripper contract) and is outermost so the clone protects the caller's request before otelhttp also touches headers; `X-Request-Id` is only set when present and not already set.

Lives in the `telemetry` package next to `StartSpan`/`SpanFunc`. The round-trip test proves a caller's trace + request id reach a downstream `otelecho` server.

### Verification
- `make pre-commit`, `go build ./...`, `go test ./...` all green. `otelhttp v0.69.0` (core stays v1.44.0). TDD; review clean (no Critical/Important).
