### PR TITLE
docs: README observability section for the OTel-only release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
+follows [Semantic Versioning](https://semver.org/spec/v2.0.0/) — while on `0.x`,
+minor releases may include breaking changes.
+
+## [Unreleased]
+
+Observability moves fully onto OpenTelemetry: a single traces + metrics
+bootstrap, env-driven exporters and sampling, stable semantic conventions via
+`otelecho`, Go runtime metrics + exemplars, worker observability, and outbound
+trace propagation.
+
+### Added
+
+- `telemetry.Init` — one OpenTelemetry bootstrap (shared resource, env-driven
+  exporters/sampling, one shutdown) replacing the old `tracer.go`.
+- `fctx.Fields` / `fctx.NewRequestID` / `fctx.WithNewRequestID` — a single
+  correlation-ID emission point (`trace_id`/`span_id`/`request_id`).
+- Go runtime metrics (`go.*`) and exemplars (`trace_based`).
+- Worker observability: per-run seeded context tagged `worker=<name>` and a
+  `fastecho.worker.failures{worker,kind}` counter.
+- `telemetry.WrapClient` / `telemetry.WrapTransport` — outbound propagation of
+  `traceparent` (via `otelhttp`) and `X-Request-Id`.
+- `Opts.Logs.Skip` — disable the access-log middleware.
+- Access-log lines now carry `trace_id`/`span_id`/`request_id`.
+
+### Breaking changes
+
+- **Package renamed:** update import `github.com/ingka-group/fastecho/otel` →
+  `…/telemetry` and call sites `otel.StartSpan` / `otel.SpanFunc` →
+  `telemetry.StartSpan` / `telemetry.SpanFunc`.
+- **Hand-rolled trace middleware removed:** drop any direct registration of
+  `otel.Middleware`, `otel.WithSkipper`, or `otel.WithTracerProvider` — fastecho
+  wires `otelecho` itself.
+- **Metric renames:**
+
+  | Old name                                    | New name                                                         |
+  |---------------------------------------------|------------------------------------------------------------------|
+  | `echo_http_requests_total`                  | derive from `http_server_request_duration_seconds_count`         |
+  | `echo_http_request_duration_seconds_bucket` | `http_server_request_duration_seconds_bucket`                    |
+  | label `code`                                | `http_response_status_code`                                      |
+  | label `url`                                 | `http_route` (rename only — value was already the route pattern) |
+
+- **Span attribute renames:** `http.*` / `net.*` → stable semconv
+  (`http.request.method`, `url.path`, `http.route`, `http.response.status_code`).
+  `fastecho.request_id` is also set on the server span.
+- **`/metrics` survives — no action needed:** fastecho defaults
+  `OTEL_METRICS_EXPORTER` to `prometheus`, so an existing app that sets nothing
+  still gets `/metrics` on the main port. Only the metric names change (above).
+- **OTLP transport stays gRPC** (`:4317`) by default — existing collectors keep
+  working. Set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` to opt into the OTel
+  default (`:4318`).
+- **`prometheus.DefaultRegisterer` reset removed** — fastecho no longer mutates
+  global Prometheus state.
+- **Log level field is now lowercase** (`"level":"info"`, was `"INFO"`) — update
+  any log filter or alert that matched uppercase `INFO`/`WARN`/`ERROR`.
+- **`Config.Workers` is now `map[string]Worker`** (was `[]Worker`): the map key
+  is the worker name. Migrate `Workers: []fastecho.Worker{fn}` →
+  `Workers: map[string]fastecho.Worker{"my-worker": fn}`.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ fastecho emits **traces + metrics** through OpenTelemetry from one shared
 resource and one shutdown. Logs stay on zap (stdout JSON) and carry
 `trace_id`/`span_id`/`request_id` so they correlate without a log exporter.
 
+New here? The [observability guide](docs/observability.md) explains how traces,
+metrics, and logs tie together (correlation IDs, pull vs push, exemplars) and
+what happens under the hood.
+
 Behaviour is configured by standard `OTEL_*` env vars (read by the OTel SDK and
 `autoexport`); `fastecho.Opts` only carries on/off toggles.
 
@@ -212,10 +216,6 @@ exporter, endpoint): one source of truth per setting.
 | Semantic conventions        | [`semconv/v1.41.0`](https://pkg.go.dev/go.opentelemetry.io/otel/semconv/v1.41.0)                               |
 
 Full env reference: [OpenTelemetry SDK environment variables](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/).
-
-New here? The [observability guide](docs/observability.md) explains how traces,
-metrics, and logs tie together (correlation IDs, pull vs push, exemplars) and
-what happens under the hood.
 
 #### Instrumentation coverage
 

--- a/README.md
+++ b/README.md
@@ -161,31 +161,79 @@ config := fastecho.Config{
 }
 ```
 
-### OTEL tracing (optional)
+### Observability (OpenTelemetry)
 
-Tracing is enabled when `Opts.Tracing.Skip` is `false` (the default). The service name and exporter endpoint are configured via standard OpenTelemetry env vars:
+fastecho emits **traces + metrics** through OpenTelemetry from one shared
+resource and one shutdown. Logs stay on zap (stdout JSON) and carry
+`trace_id`/`span_id`/`request_id` so they correlate without a log exporter.
 
-| Env Variable                  | Purpose                                                             |
-|-------------------------------|---------------------------------------------------------------------|
-| `OTEL_SERVICE_NAME`           | Sets the service name for traces                                    |
-| `OTEL_RESOURCE_ATTRIBUTES`    | Additional resource attributes (e.g. `deployment.environment=prod`) |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | gRPC endpoint for the OTLP exporter                                 |
+Behaviour is configured by standard `OTEL_*` env vars (read by the OTel SDK and
+`autoexport`); `fastecho.Opts` only carries on/off toggles.
 
-| Layer                 | How                            | Effort              |
-|-----------------------|--------------------------------|---------------------|
-| HTTP requests         | Automatic via middleware       | Zero config         |
-| Database (GORM)       | `gorm.io/plugin/opentelemetry` | Add plugin yourself |
-| Service functions     | `otel.StartSpan(ctx)`          | 2 lines             |
-| Functions without ctx | `otel.SpanFunc(ctx, name, fn)` | 3 lines             |
-| Outbound HTTP         | `otelhttp.NewTransport(rt)`    | Wrap your client    |
+#### Env vars
+
+| Variable | Default | Effect |
+|---|---|---|
+| `OTEL_SERVICE_NAME` | (unset) | `service.name` on every span/metric |
+| `OTEL_SERVICE_VERSION` | (unset) | `service.version` (optional) |
+| `OTEL_RESOURCE_ATTRIBUTES` | (unset) | Extra resource attrs, e.g. `deployment.environment=prod` |
+| `OTEL_TRACES_EXPORTER` | `otlp` | `otlp` \| `console` \| `none` |
+| `OTEL_METRICS_EXPORTER` | `prometheus` | `prometheus` (served at `/metrics`) \| `otlp` (push) \| `none` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `localhost:4317` | Collector endpoint (gRPC port, matching the default protocol) |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` (fastecho default) | Set `http/protobuf` for a `:4318` collector |
+| `OTEL_TRACES_SAMPLER` | `parentbased_always_on` | e.g. `parentbased_traceidratio` |
+| `OTEL_TRACES_SAMPLER_ARG` | `1.0` | Sample ratio for the ratio samplers |
+| `OTEL_METRICS_EXEMPLAR_FILTER` | `trace_based` | Which measurements carry trace exemplars |
+
+> `/metrics` stays on the service's main port (default `prometheus` exporter).
+> The metric is `http_server_request_duration_seconds_*` (was `echo_http_*`).
+
+#### Code toggles (`fastecho.Opts`)
+
+| Field | Effect |
+|---|---|
+| `Opts.Tracing.Skip` | Disable tracing |
+| `Opts.Metrics.Skip` | Disable metrics (and `/metrics`) |
+| `Opts.Logs.Skip` | Disable the access-log middleware |
+
+There are intentionally **no** code fields mirroring an env var (sampler ratio,
+exporter, endpoint): one source of truth per setting.
+
+#### Libraries
+
+| Concern | Package |
+|---|---|
+| SDK + API | [`go.opentelemetry.io/otel`](https://pkg.go.dev/go.opentelemetry.io/otel) |
+| HTTP server spans + metrics | [`otelecho`](https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho) |
+| Env-driven exporters | [`autoexport`](https://pkg.go.dev/go.opentelemetry.io/contrib/exporters/autoexport) |
+| Go runtime metrics | [`instrumentation/runtime`](https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/runtime) |
+| Outbound client transport | [`otelhttp`](https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp) |
+| `/metrics` exporter | [`exporters/prometheus`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/prometheus) |
+| Semantic conventions | [`semconv/v1.41.0`](https://pkg.go.dev/go.opentelemetry.io/otel/semconv/v1.41.0) |
+
+Full env reference: [OpenTelemetry SDK environment variables](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/).
+
+New here? The [observability guide](docs/observability.md) explains how traces,
+metrics, and logs tie together (correlation IDs, pull vs push, exemplars) and
+what happens under the hood.
+
+#### Instrumentation coverage
+
+| Layer                 | How                                   | Effort              |
+|-----------------------|---------------------------------------|---------------------|
+| HTTP requests         | Automatic via middleware              | Zero config         |
+| Database (GORM)       | `gorm.io/plugin/opentelemetry`        | Add plugin yourself |
+| Service functions     | `telemetry.StartSpan(ctx)`            | 2 lines             |
+| Functions without ctx | `telemetry.SpanFunc(ctx, name, fn)`   | 3 lines             |
+| Outbound HTTP         | `telemetry.WrapClient(c)`             | Wrap your client    |
 
 Per-function tracing:
 
 ```go
-import "github.com/ingka-group/fastecho/otel"
+import "github.com/ingka-group/fastecho/telemetry"
 
 func (s *Service) Process(ctx context.Context, input Input) error {
-    ctx, span := otel.StartSpan(ctx)
+    ctx, span := telemetry.StartSpan(ctx)
     defer span.End()
     // span name auto-discovered: "mypackage.Service.Process"
     return s.repo.Save(ctx, input)
@@ -196,9 +244,17 @@ Tracing a function without context:
 
 ```go
 var result T
-otel.SpanFunc(ctx, "heavy-algorithm", func() {
+telemetry.SpanFunc(ctx, "heavy-algorithm", func() {
     result = computeHeavyAlgorithm(data)
 })
+```
+
+Outbound HTTP calls:
+
+```go
+client := telemetry.WrapClient(&http.Client{Timeout: 5 * time.Second})
+// client injects traceparent + X-Request-Id on every outbound request
+resp, err := client.Do(req.WithContext(ctx))
 ```
 
 For database tracing, add `gorm.io/plugin/opentelemetry` to your project:
@@ -210,6 +266,29 @@ _ = db.Use(tracing.NewPlugin())
 ```
 
 **Important:** Always pass context to GORM queries (`db.WithContext(ctx).Find(...)`) so DB spans attach to the request trace.
+
+#### Breaking changes
+
+This release upgrades fastecho from a custom `otel` package to native OpenTelemetry.
+Existing consumers must check the following:
+
+- **Package renamed:** update import `github.com/ingka-group/fastecho/otel` → `…/telemetry` and call sites `otel.StartSpan` / `otel.SpanFunc` → `telemetry.StartSpan` / `telemetry.SpanFunc`.
+- **Hand-rolled trace middleware removed:** drop any direct registration of `otel.Middleware`, `otel.WithSkipper`, or `otel.WithTracerProvider` — fastecho wires `otelecho` itself.
+- **Metric renames:**
+
+  | Old name | New name |
+  |---|---|
+  | `echo_http_requests_total` | derive from `http_server_request_duration_seconds_count` |
+  | `echo_http_request_duration_seconds_bucket` | `http_server_request_duration_seconds_bucket` |
+  | label `code` | `http_response_status_code` |
+  | label `url` | `http_route` (rename only — value was already the route pattern) |
+
+- **Span attribute renames:** `http.*` / `net.*` → stable semconv (`http.request.method`, `url.path`, `http.route`, `http.response.status_code`). `fastecho.request_id` is also set on the server span.
+- **`/metrics` survives — no action needed:** fastecho defaults `OTEL_METRICS_EXPORTER` to `prometheus` so an existing app that sets nothing still gets `/metrics` on the main port. Only the metric names change (see above).
+- **OTLP transport stays gRPC** (`:4317`) by default — existing collectors keep working. Set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` to opt into the OTel default (`:4318`).
+- **`prometheus.DefaultRegisterer` reset removed** — fastecho no longer mutates global Prometheus state.
+- **Log level field is now lowercase** (`"level":"info"` was `"INFO"`) — update any log filter or alert that matched uppercase `INFO`/`WARN`/`ERROR`.
+- **`Config.Workers` is now `map[string]Worker`** (was `[]Worker`): the map key is the worker name. Migrate `Workers: []fastecho.Worker{fn}` → `Workers: map[string]fastecho.Worker{"my-worker": fn}`.
 
 ### Database (optional)
 
@@ -224,8 +303,8 @@ A `Worker` is a plain function that should block until its context is cancelled:
 ```go
 config := fastecho.Config{
 	Routes: configureRoutes,
-	Workers: []fastecho.Worker{
-		func(ctx context.Context) error {
+	Workers: map[string]fastecho.Worker{
+		"pubsub-listener": func(ctx context.Context) error {
 			return pubsub.StartListener(ctx, "project", "subscription")
 		},
 	},

--- a/README.md
+++ b/README.md
@@ -267,28 +267,10 @@ _ = db.Use(tracing.NewPlugin())
 
 **Important:** Always pass context to GORM queries (`db.WithContext(ctx).Find(...)`) so DB spans attach to the request trace.
 
-#### Breaking changes
+#### Upgrading
 
-This release upgrades fastecho from a custom `otel` package to native OpenTelemetry.
-Existing consumers must check the following:
-
-- **Package renamed:** update import `github.com/ingka-group/fastecho/otel` → `…/telemetry` and call sites `otel.StartSpan` / `otel.SpanFunc` → `telemetry.StartSpan` / `telemetry.SpanFunc`.
-- **Hand-rolled trace middleware removed:** drop any direct registration of `otel.Middleware`, `otel.WithSkipper`, or `otel.WithTracerProvider` — fastecho wires `otelecho` itself.
-- **Metric renames:**
-
-  | Old name                                    | New name                                                         |
-  |---------------------------------------------|------------------------------------------------------------------|
-  | `echo_http_requests_total`                  | derive from `http_server_request_duration_seconds_count`         |
-  | `echo_http_request_duration_seconds_bucket` | `http_server_request_duration_seconds_bucket`                    |
-  | label `code`                                | `http_response_status_code`                                      |
-  | label `url`                                 | `http_route` (rename only — value was already the route pattern) |
-
-- **Span attribute renames:** `http.*` / `net.*` → stable semconv (`http.request.method`, `url.path`, `http.route`, `http.response.status_code`). `fastecho.request_id` is also set on the server span.
-- **`/metrics` survives — no action needed:** fastecho defaults `OTEL_METRICS_EXPORTER` to `prometheus` so an existing app that sets nothing still gets `/metrics` on the main port. Only the metric names change (see above).
-- **OTLP transport stays gRPC** (`:4317`) by default — existing collectors keep working. Set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` to opt into the OTel default (`:4318`).
-- **`prometheus.DefaultRegisterer` reset removed** — fastecho no longer mutates global Prometheus state.
-- **Log level field is now lowercase** (`"level":"info"` was `"INFO"`) — update any log filter or alert that matched uppercase `INFO`/`WARN`/`ERROR`.
-- **`Config.Workers` is now `map[string]Worker`** (was `[]Worker`): the map key is the worker name. Migrate `Workers: []fastecho.Worker{fn}` → `Workers: map[string]fastecho.Worker{"my-worker": fn}`.
+Upgrading from an earlier fastecho version? See [CHANGELOG.md](CHANGELOG.md) for
+the full list of breaking changes and migration steps.
 
 ### Database (optional)
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ if err := fastecho.Run(&config); err != nil {
 
 ## Features
 
+- [Logger](#logger)
+- [Request context](#request-context)
+- [Routing](#routing)
+- [Request validation](#request-validation)
+- [Middleware](#middleware)
+- [Swagger](#swagger)
+- [Health probe endpoints](#health-probe-endpoints)
+- [Environment variables](#environment-variables)
+- [Observability (OpenTelemetry)](#observability-opentelemetry)
+- [Database](#database-optional)
+- [Background workers](#background-workers)
+- [Plugins](#plugins)
+- [Access Echo instance](#access-echo-instance)
+
 ### Logger
 
 We integrated `go.uber.org/zap`

--- a/README.md
+++ b/README.md
@@ -172,44 +172,44 @@ Behaviour is configured by standard `OTEL_*` env vars (read by the OTel SDK and
 
 #### Env vars
 
-| Variable | Default | Effect |
-|---|---|---|
-| `OTEL_SERVICE_NAME` | (unset) | `service.name` on every span/metric |
-| `OTEL_SERVICE_VERSION` | (unset) | `service.version` (optional) |
-| `OTEL_RESOURCE_ATTRIBUTES` | (unset) | Extra resource attrs, e.g. `deployment.environment=prod` |
-| `OTEL_TRACES_EXPORTER` | `otlp` | `otlp` \| `console` \| `none` |
-| `OTEL_METRICS_EXPORTER` | `prometheus` | `prometheus` (served at `/metrics`) \| `otlp` (push) \| `none` |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | `localhost:4317` | Collector endpoint (gRPC port, matching the default protocol) |
-| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` (fastecho default) | Set `http/protobuf` for a `:4318` collector |
-| `OTEL_TRACES_SAMPLER` | `parentbased_always_on` | e.g. `parentbased_traceidratio` |
-| `OTEL_TRACES_SAMPLER_ARG` | `1.0` | Sample ratio for the ratio samplers |
-| `OTEL_METRICS_EXEMPLAR_FILTER` | `trace_based` | Which measurements carry trace exemplars |
+| Variable                       | Default                   | Effect                                                         |
+|--------------------------------|---------------------------|----------------------------------------------------------------|
+| `OTEL_SERVICE_NAME`            | (unset)                   | `service.name` on every span/metric                            |
+| `OTEL_SERVICE_VERSION`         | (unset)                   | `service.version` (optional)                                   |
+| `OTEL_RESOURCE_ATTRIBUTES`     | (unset)                   | Extra resource attrs, e.g. `deployment.environment=prod`       |
+| `OTEL_TRACES_EXPORTER`         | `otlp`                    | `otlp` \| `console` \| `none`                                  |
+| `OTEL_METRICS_EXPORTER`        | `prometheus`              | `prometheus` (served at `/metrics`) \| `otlp` (push) \| `none` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`  | `localhost:4317`          | Collector endpoint (gRPC port, matching the default protocol)  |
+| `OTEL_EXPORTER_OTLP_PROTOCOL`  | `grpc` (fastecho default) | Set `http/protobuf` for a `:4318` collector                    |
+| `OTEL_TRACES_SAMPLER`          | `parentbased_always_on`   | e.g. `parentbased_traceidratio`                                |
+| `OTEL_TRACES_SAMPLER_ARG`      | `1.0`                     | Sample ratio for the ratio samplers                            |
+| `OTEL_METRICS_EXEMPLAR_FILTER` | `trace_based`             | Which measurements carry trace exemplars                       |
 
 > `/metrics` stays on the service's main port (default `prometheus` exporter).
 > The metric is `http_server_request_duration_seconds_*` (was `echo_http_*`).
 
 #### Code toggles (`fastecho.Opts`)
 
-| Field | Effect |
-|---|---|
-| `Opts.Tracing.Skip` | Disable tracing |
-| `Opts.Metrics.Skip` | Disable metrics (and `/metrics`) |
-| `Opts.Logs.Skip` | Disable the access-log middleware |
+| Field               | Effect                            |
+|---------------------|-----------------------------------|
+| `Opts.Tracing.Skip` | Disable tracing                   |
+| `Opts.Metrics.Skip` | Disable metrics (and `/metrics`)  |
+| `Opts.Logs.Skip`    | Disable the access-log middleware |
 
 There are intentionally **no** code fields mirroring an env var (sampler ratio,
 exporter, endpoint): one source of truth per setting.
 
 #### Libraries
 
-| Concern | Package |
-|---|---|
-| SDK + API | [`go.opentelemetry.io/otel`](https://pkg.go.dev/go.opentelemetry.io/otel) |
+| Concern                     | Package                                                                                                        |
+|-----------------------------|----------------------------------------------------------------------------------------------------------------|
+| SDK + API                   | [`go.opentelemetry.io/otel`](https://pkg.go.dev/go.opentelemetry.io/otel)                                      |
 | HTTP server spans + metrics | [`otelecho`](https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho) |
-| Env-driven exporters | [`autoexport`](https://pkg.go.dev/go.opentelemetry.io/contrib/exporters/autoexport) |
-| Go runtime metrics | [`instrumentation/runtime`](https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/runtime) |
-| Outbound client transport | [`otelhttp`](https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp) |
-| `/metrics` exporter | [`exporters/prometheus`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/prometheus) |
-| Semantic conventions | [`semconv/v1.41.0`](https://pkg.go.dev/go.opentelemetry.io/otel/semconv/v1.41.0) |
+| Env-driven exporters        | [`autoexport`](https://pkg.go.dev/go.opentelemetry.io/contrib/exporters/autoexport)                            |
+| Go runtime metrics          | [`instrumentation/runtime`](https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/runtime)            |
+| Outbound client transport   | [`otelhttp`](https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp)                 |
+| `/metrics` exporter         | [`exporters/prometheus`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/prometheus)                     |
+| Semantic conventions        | [`semconv/v1.41.0`](https://pkg.go.dev/go.opentelemetry.io/otel/semconv/v1.41.0)                               |
 
 Full env reference: [OpenTelemetry SDK environment variables](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/).
 
@@ -276,12 +276,12 @@ Existing consumers must check the following:
 - **Hand-rolled trace middleware removed:** drop any direct registration of `otel.Middleware`, `otel.WithSkipper`, or `otel.WithTracerProvider` — fastecho wires `otelecho` itself.
 - **Metric renames:**
 
-  | Old name | New name |
-  |---|---|
-  | `echo_http_requests_total` | derive from `http_server_request_duration_seconds_count` |
-  | `echo_http_request_duration_seconds_bucket` | `http_server_request_duration_seconds_bucket` |
-  | label `code` | `http_response_status_code` |
-  | label `url` | `http_route` (rename only — value was already the route pattern) |
+  | Old name                                    | New name                                                         |
+  |---------------------------------------------|------------------------------------------------------------------|
+  | `echo_http_requests_total`                  | derive from `http_server_request_duration_seconds_count`         |
+  | `echo_http_request_duration_seconds_bucket` | `http_server_request_duration_seconds_bucket`                    |
+  | label `code`                                | `http_response_status_code`                                      |
+  | label `url`                                 | `http_route` (rename only — value was already the route pattern) |
 
 - **Span attribute renames:** `http.*` / `net.*` → stable semconv (`http.request.method`, `url.path`, `http.route`, `http.response.status_code`). `fastecho.request_id` is also set on the server span.
 - **`/metrics` survives — no action needed:** fastecho defaults `OTEL_METRICS_EXPORTER` to `prometheus` so an existing app that sets nothing still gets `/metrics` on the main port. Only the metric names change (see above).

--- a/docs/observability-dos-and-donts.md
+++ b/docs/observability-dos-and-donts.md
@@ -1,56 +1,42 @@
 # Observability: do's and don'ts
 
-The recommended way to use fastecho's telemetry, in brief. For *why* any of these
-hold, see [observability.md](observability.md).
+The recommended way to use fastecho's telemetry, in brief. For *why* any of these hold, see [observability.md](observability.md).
 
 ## Spans
 
-- ✅ Use `telemetry.StartSpan(ctx)` for your own spans, then `defer span.End()`.
-  It auto-names from the caller and resolves the tracer from `ctx` — so it works
-  in handlers *and* workers.
-- ❌ Don't reach for `otel.Tracer(...)` inside a worker (or any seeded context) —
-  it bypasses the ctx-scoped tracer and loses the `worker=<name>` label.
+- ✅ Use `telemetry.StartSpan(ctx)` for your own spans, then `defer span.End()`. It auto-names from the caller and resolves the tracer from `ctx` — so it works in handlers *and* workers.
+- ❌ Don't reach for `otel.Tracer(...)` inside a worker (or any seeded context) — it bypasses the ctx-scoped tracer and loses the `worker=<name>` label.
 - ✅ Span the **unit of work** (one poll, one job, one iteration).
-- ❌ Don't wrap a long-running loop or a whole worker run in a single span — it
-  stays open for the process lifetime and never exports.
+- ❌ Don't wrap a long-running loop or a whole worker run in a single span — it stays open for the process lifetime and never exports.
 - ✅ Record failures on the span: `span.RecordError(err)` + `span.SetStatus(codes.Error, …)`.
 
 ## Goroutines
 
-- ✅ Detach cancellation but keep the trace when you spawn work that outlives the
-  request:
+- ✅ Detach cancellation but keep the trace when you spawn work that outlives the request:
   ```go
   gctx := context.WithoutCancel(ctx)
   go func() { ctx, span := telemetry.StartSpan(gctx); defer span.End(); /* … */ }()
   ```
-- ❌ Don't hand a request's `ctx` straight to a goroutine that outlives the
-  handler — it's cancelled the moment the handler returns.
+- ❌ Don't hand a request's `ctx` straight to a goroutine that outlives the handler — it's cancelled the moment the handler returns.
 
 ## Logging
 
-- ✅ Use `fctx.Logger(ctx)` — it carries `trace_id`/`span_id`/`request_id`, so
-  every line correlates to its trace.
-- ❌ Don't use a package-level or global logger in request/worker code — you lose
-  correlation.
-- ✅ Set log levels with recognizable severities; the level field is lowercase
-  (`info`/`warn`/`error`) so backends color-code it.
-- ❌ Don't hand-log successful requests — the access log already covers 3xx+, and
-  2xx is intentionally quiet.
+- ✅ Use `fctx.Logger(ctx)` — it carries `trace_id`/`span_id`/`request_id`, so every line correlates to its trace.
+- ❌ Don't use a package-level or global logger in request/worker code — you lose correlation.
+- ✅ Set log levels with recognizable severities; the level field is lowercase (`info`/`warn`/`error`) so backends color-code it.
+- ❌ Don't hand-log successful requests — the access log already covers 3xx+, and 2xx is intentionally quiet.
 
 ## Metrics
 
 - ✅ Create instruments **once** (service/package scope) via `otel.Meter("your-scope")`.
 - ❌ Don't create counters/histograms per request.
 - ✅ Pass the request `ctx` to `Add`/`Record` so measurements pick up exemplars.
-- ❌ Don't put high-cardinality values (IDs, emails, raw paths) on metric
-  attributes — that belongs on the span. Keep metric labels bounded.
+- ❌ Don't put high-cardinality values (IDs, emails, raw paths) on metric attributes — that belongs on the span. Keep metric labels bounded.
 
 ## Outbound HTTP
 
-- ✅ Wrap service-to-service clients with `telemetry.WrapClient(&http.Client{…})`
-  so `traceparent` + `X-Request-Id` propagate.
-- ❌ Don't make outbound calls with a bare `http.Client` — the trace stops at your
-  service boundary.
+- ✅ Wrap service-to-service clients with `telemetry.WrapClient(&http.Client{…})` so `traceparent` + `X-Request-Id` propagate.
+- ❌ Don't make outbound calls with a bare `http.Client` — the trace stops at your service boundary.
 - ✅ Build requests with `http.NewRequestWithContext(ctx, …)` so the context flows.
 
 ## Context
@@ -62,11 +48,7 @@ hold, see [observability.md](observability.md).
 
 ## Configuration
 
-- ✅ Configure behavior with `OTEL_*` env vars (exporter, endpoint, sampler) — one
-  source of truth, set per deployment.
-- ✅ Disable a signal with the code toggles: `Opts.Tracing.Skip` /
-  `Opts.Metrics.Skip` / `Opts.Logs.Skip`.
-- ❌ Don't look for `Config` fields mirroring an env var (sampler ratio, exporter,
-  protocol) — by design they don't exist.
-- ✅ On an OTel Collector that only speaks gRPC, keep the default; for an
-  HTTP/protobuf collector set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`.
+- ✅ Configure behavior with `OTEL_*` env vars (exporter, endpoint, sampler) — one source of truth, set per deployment.
+- ✅ Disable a signal with the code toggles: `Opts.Tracing.Skip` / `Opts.Metrics.Skip` / `Opts.Logs.Skip`.
+- ❌ Don't look for `Config` fields mirroring an env var (sampler ratio, exporter, protocol) — by design they don't exist.
+- ✅ On an OTel Collector that only speaks gRPC, keep the default; for an HTTP/protobuf collector set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`.

--- a/docs/observability-dos-and-donts.md
+++ b/docs/observability-dos-and-donts.md
@@ -1,0 +1,72 @@
+# Observability: do's and don'ts
+
+The recommended way to use fastecho's telemetry, in brief. For *why* any of these
+hold, see [observability.md](observability.md).
+
+## Spans
+
+- ✅ Use `telemetry.StartSpan(ctx)` for your own spans, then `defer span.End()`.
+  It auto-names from the caller and resolves the tracer from `ctx` — so it works
+  in handlers *and* workers.
+- ❌ Don't reach for `otel.Tracer(...)` inside a worker (or any seeded context) —
+  it bypasses the ctx-scoped tracer and loses the `worker=<name>` label.
+- ✅ Span the **unit of work** (one poll, one job, one iteration).
+- ❌ Don't wrap a long-running loop or a whole worker run in a single span — it
+  stays open for the process lifetime and never exports.
+- ✅ Record failures on the span: `span.RecordError(err)` + `span.SetStatus(codes.Error, …)`.
+
+## Goroutines
+
+- ✅ Detach cancellation but keep the trace when you spawn work that outlives the
+  request:
+  ```go
+  gctx := context.WithoutCancel(ctx)
+  go func() { ctx, span := telemetry.StartSpan(gctx); defer span.End(); /* … */ }()
+  ```
+- ❌ Don't hand a request's `ctx` straight to a goroutine that outlives the
+  handler — it's cancelled the moment the handler returns.
+
+## Logging
+
+- ✅ Use `fctx.Logger(ctx)` — it carries `trace_id`/`span_id`/`request_id`, so
+  every line correlates to its trace.
+- ❌ Don't use a package-level or global logger in request/worker code — you lose
+  correlation.
+- ✅ Set log levels with recognizable severities; the level field is lowercase
+  (`info`/`warn`/`error`) so backends color-code it.
+- ❌ Don't hand-log successful requests — the access log already covers 3xx+, and
+  2xx is intentionally quiet.
+
+## Metrics
+
+- ✅ Create instruments **once** (service/package scope) via `otel.Meter("your-scope")`.
+- ❌ Don't create counters/histograms per request.
+- ✅ Pass the request `ctx` to `Add`/`Record` so measurements pick up exemplars.
+- ❌ Don't put high-cardinality values (IDs, emails, raw paths) on metric
+  attributes — that belongs on the span. Keep metric labels bounded.
+
+## Outbound HTTP
+
+- ✅ Wrap service-to-service clients with `telemetry.WrapClient(&http.Client{…})`
+  so `traceparent` + `X-Request-Id` propagate.
+- ❌ Don't make outbound calls with a bare `http.Client` — the trace stops at your
+  service boundary.
+- ✅ Build requests with `http.NewRequestWithContext(ctx, …)` so the context flows.
+
+## Context
+
+- ✅ Accept `context.Context` in service/handler functions and pass it down.
+- ✅ Cross from Echo to `context.Context` once at the boundary: `ctx := fctx.From(ec)`.
+- ❌ Don't thread `echo.Context` into business logic.
+- ❌ Don't stash loggers/tracers/request-ids on structs — they live on the context.
+
+## Configuration
+
+- ✅ Configure behavior with `OTEL_*` env vars (exporter, endpoint, sampler) — one
+  source of truth, set per deployment.
+- ✅ Disable a signal with the code toggles: `Opts.Tracing.Skip` /
+  `Opts.Metrics.Skip` / `Opts.Logs.Skip`.
+- ❌ Don't look for `Config` fields mirroring an env var (sampler ratio, exporter,
+  protocol) — by design they don't exist.
+- ✅ On an OTel Collector that only speaks gRPC, keep the default; for an
+  HTTP/protobuf collector set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,469 @@
+# Observability in fastecho
+
+A guide to how fastecho's telemetry works: the three signals it emits, how they
+tie together, what happens under the hood (OpenTelemetry, Prometheus, Grafana),
+and the design choices behind it.
+
+This is the **conceptual** companion to the README's Observability section — the
+README is the knob-by-knob reference (every `OTEL_*` env var and `Opts` toggle);
+this doc explains *what those knobs do and why it all fits together*. For the
+recommended way to *use* it day-to-day, see
+[do's and don'ts](observability-dos-and-donts.md).
+
+---
+
+## Overview
+
+fastecho emits **three signals**, tied together by a single correlation ID.
+
+```
+                         ┌─────────────────────────────┐
+   incoming request ───▶ │  fastecho service           │
+                         │                             │
+                         │   traces  ─── push ───▶  collector ─▶ Tempo/Jaeger
+                         │   metrics ─── pull ◀───  Prometheus
+                         │   logs    ─── stdout ─▶  your log pipeline
+                         └─────────────────────────────┘
+                                       │
+                          every signal carries trace_id
+```
+
+- **Traces** — the path of a request through your service (and across service
+  hops), as a tree of timed spans.
+- **Metrics** — aggregate numbers: request rates, latencies, Go runtime stats.
+- **Logs** — structured zap lines on stdout, now carrying correlation IDs.
+
+**`trace_id`** appears in logs, on spans, and (via *exemplars*) on metrics, so
+you can pivot from any one signal to any other.
+
+One bootstrap (`telemetry.Init`) builds one shared *resource* (the identity:
+`service.name`, `service.instance.id`), wires the exporters from environment
+variables, and returns one `Shutdown` that drains everything together. Both
+`Run` and `Initialize` go through it, so every entry point is instrumented the
+same way.
+
+---
+
+## Glossary
+
+### SDK & pipeline
+
+- **Provider** — the SDK object that produces tracers/meters; fastecho holds one
+  of each behind `telemetry.Providers`.
+- **Exporter** — the SDK component that sends a signal to a destination (OTLP,
+  Prometheus, console, none); chosen per signal via `OTEL_*_EXPORTER`.
+- **OTLP** — OpenTelemetry Protocol; the wire format for exporting telemetry
+  (gRPC on `:4317`, HTTP/protobuf on `:4318`).
+- **Collector** — a standalone OpenTelemetry process that receives, processes, and
+  forwards telemetry; sits between the app and the backend.
+- **Pull / push** — whether the backend scrapes the app (`/metrics`) or the app
+  exports to the backend (OTLP).
+- **semconv** — OpenTelemetry's standard attribute/metric names.
+
+### Traces
+
+- **Span** — one timed operation; the unit of a trace.
+- **Trace** — a tree of spans for one request, possibly spanning services.
+- **Tracer** — the per-scope SDK object that creates spans; obtained from the
+  tracer provider.
+- **`traceparent`** — the W3C header that carries trace context between services.
+- **Sampler** — decides which traces are recorded vs dropped. Configured by
+  `OTEL_TRACES_SAMPLER` / `OTEL_TRACES_SAMPLER_ARG`; defaults to
+  `parentbased_always_on` (keep all, honoring the caller's decision).
+
+### Metrics
+
+- **Meter** — the per-scope SDK object that creates metric instruments; obtained
+  from the meter provider.
+- **Instrument** — the handle you record a metric on: Counter (monotonic sum),
+  Histogram (distribution, e.g. latency), Gauge (current value).
+- **Exemplar** — an example measurement on a metric bucket, carrying a `trace_id`
+  that links the aggregate to a specific trace.
+- **Cardinality** — the number of distinct time series a metric produces; one per
+  distinct attribute combination, so bounded attribute values keep it in check.
+
+---
+
+## Design decisions
+
+The key choices behind fastecho's telemetry:
+
+- **One correlation-ID source.** `trace_id`/`span_id`/`request_id` are assembled
+  in a single place — `fctx.Fields(ctx)` — and reused by the request middleware,
+  the panic recover handler, the access log, and worker seeds. One emission point
+  means every signal correlates identically, with no per-call-site drift.
+- **Env is the single source of truth.** Sampling ratio, exporter, and endpoint
+  live only in `OTEL_*` env, never duplicated as struct fields — so the same
+  binary is configured per deployment and there's no second place to disagree.
+- **Global registration is internal, not a public toggle.** Registering the
+  providers + propagator as the OTel globals is always on for `Run`/`Initialize`
+  and isn't exposed on `fastecho.Config`. There's no legitimate production reason
+  to turn it off, and doing so would silently break `traceparent` propagation
+  (otelecho/otelhttp read the global propagator). Tests get isolation via injected
+  providers instead.
+- **Don't hand-roll what the SDK does.** No custom sampler (the SDK reads the env
+  and handles every standard value); no custom server-span middleware (`otelecho`).
+  Less code, fewer ways to be subtly wrong.
+- **Span helpers read the tracer from context.** `telemetry.StartSpan`/`SpanFunc`
+  resolve `fctx.Tracer(ctx)`, not the OTel global. This keeps them consistent with
+  the rest of `fctx` (logger/tracer/request-id all flow through the context),
+  makes `fctx.WithTracer` meaningful, and lets tests and multiple instances use
+  isolated providers without mutating global state. In production the middleware
+  seeds the context with the global's tracer, so behavior is identical; with none
+  set, it falls back to a no-op.
+- **Metrics default to pull.** Long-lived servers are ideal scrape targets, pull
+  gives a free up/down signal, and it keeps `/metrics` working for existing
+  Prometheus setups. fastecho builds its own Prometheus exporter and registry for
+  this — `autoexport` would otherwise start a separate server on `:9464` and leave
+  `/metrics` empty — so the endpoint stays on the service's main port. Switch to
+  `OTEL_METRICS_EXPORTER=otlp` for push.
+- **OTLP transport defaults to gRPC** (`:4317`), preserving fastecho's previous
+  behavior so existing deployments upgrade untouched. It's no longer *hardcoded* —
+  set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` to use the OTel default
+  (`:4318`). fastecho sets this default only when the var is unset, so operators
+  keep full control. (Same reasoning as the metrics-exporter default: override an
+  SDK default to preserve existing behavior, but stay overridable.)
+- **Outbound client wraps, doesn't replace.** `telemetry.WrapClient`/
+  `WrapTransport` decorate a normal `*http.Client`/`RoundTripper` with
+  `traceparent` injection and `X-Request-Id` forwarding — no factory, options, or
+  typed verbs. The caller keeps full control of timeout, redirects, and headers;
+  fastecho only adds the propagation that's specific to it.
+- **Logs stay on zap.** Correlation comes from structured fields, not a log
+  exporter — your platform already ships stdout.
+
+---
+
+## Correlation IDs
+
+Three IDs travel with every request:
+
+| ID           | What it is                                                | Where it comes from                                                    |
+|--------------|-----------------------------------------------------------|------------------------------------------------------------------------|
+| `trace_id`   | Identifies the whole request, end to end, across services | The active span (created by `otelecho`)                                |
+| `span_id`    | Identifies one operation within the trace                 | The active span                                                        |
+| `request_id` | A fastecho-level request identifier (UUIDv4)              | The request-id middleware, or forwarded from an inbound `X-Request-Id` |
+
+They are built in **one place** — `fctx.Fields(ctx)` — so middleware, the panic
+recover handler, the access log, and background workers all derive them
+identically. `Fields` reads `trace_id`/`span_id` from the active span context and
+`request_id` from the request context, and returns them as structured log fields.
+
+Discrete fields (not the raw `traceparent` header) let the log backend **query
+by `trace_id`** and link a line to its trace.
+
+On the trace side, the request id also rides along as a span attribute
+(`fastecho.request_id`), so you can find a trace from a request id and vice versa.
+
+---
+
+## Traces
+
+A **trace** is a tree of **spans**. Each span is a timed operation with a name,
+start/end, attributes, and a parent. The root span for an HTTP request is created
+by **`otelecho`**, the upstream Echo instrumentation — fastecho no longer
+hand-rolls this.
+
+**Server spans.** `otelecho` starts a span per request and records it on **stable
+semantic conventions** (semconv): `http.request.method`, `http.route`,
+`http.response.status_code`, `url.path`, etc. These names are an ecosystem
+standard, so any OTel-aware backend or dashboard understands them out of the box.
+
+**Spans in your own code.** Inside a handler or service, use the helpers:
+
+```go
+ctx, span := telemetry.StartSpan(ctx) // auto-named after the calling function
+defer span.End()
+```
+
+`StartSpan` resolves the tracer from `ctx` (`fctx.Tracer(ctx)`), so it uses
+whichever provider the request is running under — and falls back to a no-op
+tracer (zero spans, no panic) if tracing is off.
+
+**Propagation.** Trace context crosses service hops via the W3C `traceparent`
+propagator, registered globally:
+
+- **Inbound:** `otelecho` extracts `traceparent` and continues the upstream trace.
+- **Outbound:** `telemetry.WrapClient` injects `traceparent` (and forwards
+  `X-Request-Id`) onto every request — see [Outbound calls](#outbound-calls).
+
+**Sampling.** How many traces are kept is **env-driven**, read directly by the
+OTel SDK from `OTEL_TRACES_SAMPLER` / `OTEL_TRACES_SAMPLER_ARG`. fastecho does
+*not* hand-roll a sampler — the SDK already handles every standard value
+(`always_on`, `always_off`, ratio-based, and the `parentbased_*` variants) and
+defaults to `parentbased_always_on` (keep everything, respecting the caller's
+decision). "ParentBased" means: if an incoming request was already sampled
+upstream, honor that; only the root of a new trace consults the ratio.
+
+---
+
+## Metrics
+
+A **metric** is an aggregate number over time. fastecho produces four families:
+
+1. **HTTP server metrics** (from `otelecho`) — request duration histograms and
+   counts, on stable semconv names like
+   `http_server_request_duration_seconds_*` (labelled by route pattern —
+   `http_route` — so the series stay bounded).
+2. **Go runtime metrics** (`go.*`) — GC, goroutines, memory, from the OTel
+   runtime instrumentation.
+3. **Worker failures** — `fastecho.worker.failures{worker,kind}` (`kind` =
+   `panic`|`error`), a framework counter for background-worker failures. Workers
+   aren't on the auto-traced HTTP path, so this is what makes them *alertable*:
+   `rate(fastecho_worker_failures_total{worker="…"}[5m]) > 0`. Normal/cancelled
+   shutdowns don't count.
+4. **Whatever you record** — `telemetry.Init` registers the meter provider as the
+   OTel **global**, so record custom metrics with plain OTel via `otel.Meter(...)`
+   (see the [OpenTelemetry Go metrics docs](https://opentelemetry.io/docs/languages/go/instrumentation/#metrics)).
+   Pass the request `ctx` to `Add`/`Record` so measurements pick up exemplars, and
+   keep attribute values low-cardinality (high-cardinality detail belongs on the
+   span, not the metric).
+
+### The `/metrics` endpoint
+
+By default fastecho serves metrics at **`/metrics` on the service's main port**,
+in Prometheus format, for a Prometheus server to scrape. (More on that delivery
+model in [Pull vs push](#pull-vs-push).) The metric names changed from the old
+`echo_http_*` to the semconv `http_server_request_duration_seconds_*` — see the
+README's Breaking changes section.
+
+---
+
+## Logs
+
+Logs **stay on zap** — structured JSON on stdout. There is intentionally **no
+OTLP log bridge**: shipping logs is your platform's job (stdout → your log
+pipeline), and `fctx.Logger(ctx)` remains a plain `*zap.Logger`.
+
+Logs now **carry the correlation fields** (`trace_id`/`span_id`/`request_id`) via
+`fctx.Fields`, so a log line links to its trace without any log exporter. The
+access log, the panic recover handler, and worker logs all use the same
+enrichment.
+
+The access log logs 3xx/4xx/5xx responses (2xx stays quiet) and keeps the error
+string on 5xx lines, so a failing request leaves both a log entry *and* an error
+on its span.
+
+---
+
+## Pull vs push
+
+**Delivery model (pull/push) and wire transport (gRPC/HTTP) are two different
+axes.**
+
+**Metrics** can be delivered either way:
+
+|                  | **Pull** (default)                   | **Push** (opt-in)                                |
+|------------------|--------------------------------------|--------------------------------------------------|
+| How              | Prometheus scrapes `/metrics`        | App pushes via OTLP to a collector               |
+| App does         | Just expose current state            | Run an export loop, buffer, retry                |
+| Liveness         | Free — a failed scrape = target down | Ambiguous — no data could mean crashed *or* idle |
+| Short-lived jobs | Weak (may exit before scrape)        | Strong (push before exit)                        |
+| Set via          | `OTEL_METRICS_EXPORTER=prometheus`   | `OTEL_METRICS_EXPORTER=otlp`                     |
+
+fastecho **defaults to pull**: its services are long-lived HTTP servers with
+stable network identity (ideal scrape targets), pull gives a free up/down signal,
+and the framework only has to expose a registry. Push suits short-lived jobs or a
+single unified OTLP pipeline.
+
+**Traces are always push** — there's no pull model for spans:
+
+|         | Readable current *state*?   | Volume         | Model      |
+|---------|-----------------------------|----------------|------------|
+| Metrics | Yes (a counter/gauge value) | Small, bounded | Pull works |
+| Traces  | No (completed *events*)     | High, bursty   | Push only  |
+
+A metric is a value that exists *now* and can be read on demand. A span is a past
+*event* — by the time you'd pull it, it's already over and would have to be
+buffered waiting for you. Spans are also a firehose. So every tracing protocol
+(OTLP, Jaeger, Zipkin) is push; there is no `/metrics`-equivalent for spans.
+
+> In the **default** config, fastecho runs two delivery models at once: traces
+> **push** (OTLP), metrics **pull** (scrape). Setting `OTEL_METRICS_EXPORTER=otlp`
+> unifies them onto one OTLP push pipeline — simpler to operate (one endpoint,
+> one collector) at the cost of the free scrape-based liveness signal.
+
+---
+
+## Exemplars: jumping from a metric to a trace
+
+Exemplars link an aggregated metric back to an individual trace.
+
+Metrics are aggregates, and aggregation throws away individual identity. A
+histogram bucket says:
+
+```
+http_server_request_duration_seconds_bucket{le="0.25"} 47
+```
+
+"47 requests finished under 250ms" — but not *which* 47. When p99 latency spikes,
+the metric shows something is slow, not which request, leaving you to search
+traces by time range.
+
+**An exemplar** is a concrete example measurement attached to a metric bucket,
+carrying the `trace_id` of a request that landed there:
+
+```
+http_server_request_duration_seconds_bucket{le="0.25"} 47 # {trace_id="4bf92f...",span_id="00f0..."} 0.237 1700000000
+```
+
+That trailing part is one specific request that took 0.237s, and the exact trace
+you can open. In Grafana these render as **clickable dots** on the latency graph:
+click the dot on the p99 spike to jump to *that* trace's waterfall in Tempo/Jaeger.
+
+**Why it's tied to sampling** (`OTEL_METRICS_EXEMPLAR_FILTER=trace_based`, the
+default): an exemplar is only recorded when the measurement happened inside a
+**sampled** span context. Its entire value is the `trace_id` it points at — if
+that trace wasn't kept, the link would dangle. `trace_based` means "only attach
+exemplars whose trace actually got stored."
+
+**Visibility is a backend concern.** fastecho records exemplars at the SDK. To
+see and click them, the backend must be wired up: Prometheus with exemplar
+storage enabled, and a trace backend (Tempo) for Grafana to jump into.
+
+---
+
+## Backends and dashboards
+
+```
+  fastecho service
+    │
+    │  traces  ──OTLP push──▶  OpenTelemetry Collector ──▶  Tempo / Jaeger
+    │
+    │  /metrics  ◀──scrape──   Prometheus
+    │
+    └─ logs ──stdout──▶  (your log pipeline)
+
+                      Grafana
+                        ├─ Prometheus data source  → dashboards, alerts
+                        ├─ Tempo data source       → trace waterfalls
+                        └─ exemplars link Prometheus panels → Tempo traces
+```
+
+- **Prometheus** scrapes `/metrics` and stores the time series; you build
+  dashboards and alerts on `http_server_request_duration_seconds_*`, `go.*`, etc.
+- **The Collector** receives pushed traces (and optionally pushed metrics if you
+  flip to OTLP) and forwards them to **Tempo** (or Jaeger).
+- **Grafana** reads both, and — with exemplar storage + a Tempo data source — lets
+  you click an exemplar on a metrics panel straight through to the trace.
+
+The correlation IDs make the manual pivots work too: a `trace_id` in a log line
+pastes into Tempo; a `fastecho.request_id` span attribute matches the
+`request_id` in your logs.
+
+---
+
+## Deploying behind an OTel Collector
+
+In production you almost never point fastecho straight at a backend. The
+recommended topology is **app SDK → a local OpenTelemetry Collector → backend**.
+The collector owns batching, retry, and back-pressure (the SDK deliberately
+doesn't), and it's where org-wide resource attributes get injected. **The
+app→collector hop and the collector→backend hop are independent** — the collector
+can receive plain HTTP from your app and forward gRPC+TLS to the backend, so the
+backend wanting gRPC never forces gRPC on your app.
+
+The three signals reach the collector by **three different paths**:
+
+```
+  fastecho pod
+    │  traces   ──OTLP push (HTTP :4318 or gRPC :4317)──▶  collector ─▶ backend
+    │  /metrics ◀──scrape (prometheus.io/scrape)──────────  collector ─▶ backend
+    │  stdout   ──tailed by a filelog receiver───────────▶  collector ─▶ backend
+```
+
+**Traces — push OTLP to the collector.** Point `OTEL_EXPORTER_OTLP_ENDPOINT` at
+the collector. fastecho defaults the protocol to gRPC (`:4317`); for an
+HTTP/protobuf receiver (`:4318`) set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`.
+
+**Metrics — pick *one* path, not both:**
+
+- **Scrape (default):** keep `OTEL_METRICS_EXPORTER=prometheus` and let a
+  collector's `prometheus` receiver scrape `/metrics`. Annotate the pod
+  (`prometheus.io/scrape: "true"`, `prometheus.io/port`, `prometheus.io/path: "/metrics"`).
+  Zero exporter config; the metric *names* are the semconv ones.
+- **Push:** set `OTEL_METRICS_EXPORTER=otlp` and metrics push over the same OTLP
+  endpoint. This carries **exemplars natively** (the cleanest path for
+  metric→trace links). If you switch to push, **remove the scrape annotation** so
+  the collector doesn't also scrape and double-count.
+
+**Logs — nothing to configure.** A node/DaemonSet collector with a `filelog`
+receiver tails every pod's stdout and forwards it. fastecho writes JSON to
+stdout, so it's picked up automatically — no OTLP log exporter. Two app-side
+details make the logs *useful* once they land:
+
+- **Lowercase `level`.** fastecho emits `"level":"info"` so the collector can map
+  it to a log-level label and the UI can color-code by severity. (Uppercase
+  `INFO` is often not recognised by that mapping.)
+- **`trace_id` / `span_id` fields.** A collector's trace parser reads exactly
+  these JSON keys to attach trace context to each log line — which is what makes
+  a log line link to its trace in the UI. fastecho emits them via `fctx.Fields`.
+
+**Mandatory resource attributes.** Many platforms require certain resource
+attributes (team, system, environment) and *silently drop* data without them.
+Inject them at the collector (a `resource` processor) or set them on the app via
+`OTEL_RESOURCE_ATTRIBUTES` / `OTEL_SERVICE_NAME` — wherever your org standard
+lives. The collector path is convenient because it applies them uniformly.
+
+> **With the Grafana stack**, the three signals land in **Mimir** (metrics),
+> **Loki** (logs), and **Tempo** (traces), fed by the Collector above: metrics
+> scraped from `/metrics` (keep the default exporter + a `prometheus.io/scrape`
+> annotation), logs tailed from stdout into Loki, and traces pushed to the
+> Collector (gRPC `:4317` by default).
+
+---
+
+## Outbound calls
+
+When your service calls another service, the trace should continue across the
+hop. Wrap your HTTP client:
+
+```go
+client := telemetry.WrapClient(&http.Client{Timeout: 5 * time.Second})
+```
+
+`WrapClient` augments the client's transport so every request **injects
+`traceparent`** (via `otelhttp`, continuing the current trace) and **forwards
+`fctx.RequestID(ctx)` as `X-Request-Id`**. You keep a completely normal
+`*http.Client` — your timeout, redirect policy, and headers are yours; fastecho
+only decorates the transport. (`WrapTransport(base)` does the same for a bare
+`RoundTripper`, e.g. a generated client.)
+
+The result: a downstream service running this same stack continues *your* trace
+and logs *your* request id — one unbroken story across services.
+
+---
+
+## Under the hood
+
+- **OpenTelemetry SDK** is the engine. fastecho's `telemetry` package is a thin
+  bootstrap over it.
+- **`telemetry.Init`** builds one **resource** (shared identity for every
+  signal), the tracer and meter providers, env-driven exporters, and a single
+  `Shutdown` closer that drains traces and metrics together. It always returns
+  non-nil providers — when a signal is disabled it installs a **no-op** provider,
+  so nothing downstream has to nil-check.
+- **Exporters are chosen by environment**, via the OTel `autoexport` helper
+  (`OTEL_TRACES_EXPORTER`, `OTEL_METRICS_EXPORTER`). The same binary is configured
+  per deployment; fastecho adds only two `OTEL_*` defaults beyond the SDK's own,
+  both to preserve prior behavior and both overridable: metrics to `prometheus`
+  (so `/metrics` keeps serving on the main port) and OTLP transport to `grpc`.
+- **Service identity** comes from `OTEL_SERVICE_NAME` (+ `OTEL_RESOURCE_ATTRIBUTES`);
+  a `service.instance.id` is generated if you don't set one.
+- **Startup log line.** On boot, fastecho emits one structured `info` line —
+  `telemetry configured` — with the resolved exporters, OTLP protocol/endpoint,
+  and the metrics delivery model. It's a structured log rather than an ASCII
+  banner so it's queryable/alertable in your log backend (and readable in the dev
+  console), making an upgrade or misconfiguration visible immediately instead of
+  failing silently.
+
+### Configuration
+
+The control surface is two layers:
+
+- **`OTEL_*` environment variables** — *behaviour* values (which exporter, which
+  endpoint, sampling ratio), read by the OTel SDK. One source of truth per
+  setting; nothing is mirrored as a Go struct field.
+- **`fastecho.Opts`** — on/off *toggles* only: `Opts.Tracing.Skip`,
+  `Opts.Metrics.Skip`, `Opts.Logs.Skip`.
+
+See the README's Observability section for the full env-var and toggle tables.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,14 +1,8 @@
 # Observability in fastecho
 
-A guide to how fastecho's telemetry works: the three signals it emits, how they
-tie together, what happens under the hood (OpenTelemetry, Prometheus, Grafana),
-and the design choices behind it.
+A guide to how fastecho's telemetry works: the three signals it emits, how they tie together, what happens under the hood (OpenTelemetry, Prometheus, Grafana), and the design choices behind it.
 
-This is the **conceptual** companion to the README's Observability section — the
-README is the knob-by-knob reference (every `OTEL_*` env var and `Opts` toggle);
-this doc explains *what those knobs do and why it all fits together*. For the
-recommended way to *use* it day-to-day, see
-[do's and don'ts](observability-dos-and-donts.md).
+This is the **conceptual** companion to the README's Observability section — the README is the knob-by-knob reference (every `OTEL_*` env var and `Opts` toggle); this doc explains *what those knobs do and why it all fits together*. For the recommended way to *use* it day-to-day, see [do's and don'ts](observability-dos-and-donts.md).
 
 ---
 
@@ -28,19 +22,13 @@ fastecho emits **three signals**, tied together by a single correlation ID.
                           every signal carries trace_id
 ```
 
-- **Traces** — the path of a request through your service (and across service
-  hops), as a tree of timed spans.
+- **Traces** — the path of a request through your service (and across service hops), as a tree of timed spans.
 - **Metrics** — aggregate numbers: request rates, latencies, Go runtime stats.
 - **Logs** — structured zap lines on stdout, now carrying correlation IDs.
 
-**`trace_id`** appears in logs, on spans, and (via *exemplars*) on metrics, so
-you can pivot from any one signal to any other.
+**`trace_id`** appears in logs, on spans, and (via *exemplars*) on metrics, so you can pivot from any one signal to any other.
 
-One bootstrap (`telemetry.Init`) builds one shared *resource* (the identity:
-`service.name`, `service.instance.id`), wires the exporters from environment
-variables, and returns one `Shutdown` that drains everything together. Both
-`Run` and `Initialize` go through it, so every entry point is instrumented the
-same way.
+One bootstrap (`telemetry.Init`) builds one shared *resource* (the identity: `service.name`, `service.instance.id`), wires the exporters from environment variables, and returns one `Shutdown` that drains everything together. Both `Run` and `Initialize` go through it, so every entry point is instrumented the same way.
 
 ---
 
@@ -48,39 +36,27 @@ same way.
 
 ### SDK & pipeline
 
-- **Provider** — the SDK object that produces tracers/meters; fastecho holds one
-  of each behind `telemetry.Providers`.
-- **Exporter** — the SDK component that sends a signal to a destination (OTLP,
-  Prometheus, console, none); chosen per signal via `OTEL_*_EXPORTER`.
-- **OTLP** — OpenTelemetry Protocol; the wire format for exporting telemetry
-  (gRPC on `:4317`, HTTP/protobuf on `:4318`).
-- **Collector** — a standalone OpenTelemetry process that receives, processes, and
-  forwards telemetry; sits between the app and the backend.
-- **Pull / push** — whether the backend scrapes the app (`/metrics`) or the app
-  exports to the backend (OTLP).
+- **Provider** — the SDK object that produces tracers/meters; fastecho holds one of each behind `telemetry.Providers`.
+- **Exporter** — the SDK component that sends a signal to a destination (OTLP, Prometheus, console, none); chosen per signal via `OTEL_*_EXPORTER`.
+- **OTLP** — OpenTelemetry Protocol; the wire format for exporting telemetry (gRPC on `:4317`, HTTP/protobuf on `:4318`).
+- **Collector** — a standalone OpenTelemetry process that receives, processes, and forwards telemetry; sits between the app and the backend.
+- **Pull / push** — whether the backend scrapes the app (`/metrics`) or the app exports to the backend (OTLP).
 - **semconv** — OpenTelemetry's standard attribute/metric names.
 
 ### Traces
 
 - **Span** — one timed operation; the unit of a trace.
 - **Trace** — a tree of spans for one request, possibly spanning services.
-- **Tracer** — the per-scope SDK object that creates spans; obtained from the
-  tracer provider.
+- **Tracer** — the per-scope SDK object that creates spans; obtained from the tracer provider.
 - **`traceparent`** — the W3C header that carries trace context between services.
-- **Sampler** — decides which traces are recorded vs dropped. Configured by
-  `OTEL_TRACES_SAMPLER` / `OTEL_TRACES_SAMPLER_ARG`; defaults to
-  `parentbased_always_on` (keep all, honoring the caller's decision).
+- **Sampler** — decides which traces are recorded vs dropped. Configured by `OTEL_TRACES_SAMPLER` / `OTEL_TRACES_SAMPLER_ARG`; defaults to `parentbased_always_on` (keep all, honoring the caller's decision).
 
 ### Metrics
 
-- **Meter** — the per-scope SDK object that creates metric instruments; obtained
-  from the meter provider.
-- **Instrument** — the handle you record a metric on: Counter (monotonic sum),
-  Histogram (distribution, e.g. latency), Gauge (current value).
-- **Exemplar** — an example measurement on a metric bucket, carrying a `trace_id`
-  that links the aggregate to a specific trace.
-- **Cardinality** — the number of distinct time series a metric produces; one per
-  distinct attribute combination, so bounded attribute values keep it in check.
+- **Meter** — the per-scope SDK object that creates metric instruments; obtained from the meter provider.
+- **Instrument** — the handle you record a metric on: Counter (monotonic sum), Histogram (distribution, e.g. latency), Gauge (current value).
+- **Exemplar** — an example measurement on a metric bucket, carrying a `trace_id` that links the aggregate to a specific trace.
+- **Cardinality** — the number of distinct time series a metric produces; one per distinct attribute combination, so bounded attribute values keep it in check.
 
 ---
 
@@ -88,48 +64,15 @@ same way.
 
 The key choices behind fastecho's telemetry:
 
-- **One correlation-ID source.** `trace_id`/`span_id`/`request_id` are assembled
-  in a single place — `fctx.Fields(ctx)` — and reused by the request middleware,
-  the panic recover handler, the access log, and worker seeds. One emission point
-  means every signal correlates identically, with no per-call-site drift.
-- **Env is the single source of truth.** Sampling ratio, exporter, and endpoint
-  live only in `OTEL_*` env, never duplicated as struct fields — so the same
-  binary is configured per deployment and there's no second place to disagree.
-- **Global registration is internal, not a public toggle.** Registering the
-  providers + propagator as the OTel globals is always on for `Run`/`Initialize`
-  and isn't exposed on `fastecho.Config`. There's no legitimate production reason
-  to turn it off, and doing so would silently break `traceparent` propagation
-  (otelecho/otelhttp read the global propagator). Tests get isolation via injected
-  providers instead.
-- **Don't hand-roll what the SDK does.** No custom sampler (the SDK reads the env
-  and handles every standard value); no custom server-span middleware (`otelecho`).
-  Less code, fewer ways to be subtly wrong.
-- **Span helpers read the tracer from context.** `telemetry.StartSpan`/`SpanFunc`
-  resolve `fctx.Tracer(ctx)`, not the OTel global. This keeps them consistent with
-  the rest of `fctx` (logger/tracer/request-id all flow through the context),
-  makes `fctx.WithTracer` meaningful, and lets tests and multiple instances use
-  isolated providers without mutating global state. In production the middleware
-  seeds the context with the global's tracer, so behavior is identical; with none
-  set, it falls back to a no-op.
-- **Metrics default to pull.** Long-lived servers are ideal scrape targets, pull
-  gives a free up/down signal, and it keeps `/metrics` working for existing
-  Prometheus setups. fastecho builds its own Prometheus exporter and registry for
-  this — `autoexport` would otherwise start a separate server on `:9464` and leave
-  `/metrics` empty — so the endpoint stays on the service's main port. Switch to
-  `OTEL_METRICS_EXPORTER=otlp` for push.
-- **OTLP transport defaults to gRPC** (`:4317`), preserving fastecho's previous
-  behavior so existing deployments upgrade untouched. It's no longer *hardcoded* —
-  set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` to use the OTel default
-  (`:4318`). fastecho sets this default only when the var is unset, so operators
-  keep full control. (Same reasoning as the metrics-exporter default: override an
-  SDK default to preserve existing behavior, but stay overridable.)
-- **Outbound client wraps, doesn't replace.** `telemetry.WrapClient`/
-  `WrapTransport` decorate a normal `*http.Client`/`RoundTripper` with
-  `traceparent` injection and `X-Request-Id` forwarding — no factory, options, or
-  typed verbs. The caller keeps full control of timeout, redirects, and headers;
-  fastecho only adds the propagation that's specific to it.
-- **Logs stay on zap.** Correlation comes from structured fields, not a log
-  exporter — your platform already ships stdout.
+- **One correlation-ID source.** `trace_id`/`span_id`/`request_id` are assembled in a single place — `fctx.Fields(ctx)` — and reused by the request middleware, the panic recover handler, the access log, and worker seeds. One emission point means every signal correlates identically, with no per-call-site drift.
+- **Env is the single source of truth.** Sampling ratio, exporter, and endpoint live only in `OTEL_*` env, never duplicated as struct fields — so the same binary is configured per deployment and there's no second place to disagree.
+- **Global registration is internal, not a public toggle.** Registering the providers + propagator as the OTel globals is always on for `Run`/`Initialize` and isn't exposed on `fastecho.Config`. There's no legitimate production reason to turn it off, and doing so would silently break `traceparent` propagation (otelecho/otelhttp read the global propagator). Tests get isolation via injected providers instead.
+- **Don't hand-roll what the SDK does.** No custom sampler (the SDK reads the env and handles every standard value); no custom server-span middleware (`otelecho`). Less code, fewer ways to be subtly wrong.
+- **Span helpers read the tracer from context.** `telemetry.StartSpan`/`SpanFunc` resolve `fctx.Tracer(ctx)`, not the OTel global. This keeps them consistent with the rest of `fctx` (logger/tracer/request-id all flow through the context), makes `fctx.WithTracer` meaningful, and lets tests and multiple instances use isolated providers without mutating global state. In production the middleware seeds the context with the global's tracer, so behavior is identical; with none set, it falls back to a no-op.
+- **Metrics default to pull.** Long-lived servers are ideal scrape targets, pull gives a free up/down signal, and it keeps `/metrics` working for existing Prometheus setups. fastecho builds its own Prometheus exporter and registry for this — `autoexport` would otherwise start a separate server on `:9464` and leave `/metrics` empty — so the endpoint stays on the service's main port. Switch to `OTEL_METRICS_EXPORTER=otlp` for push.
+- **OTLP transport defaults to gRPC** (`:4317`), preserving fastecho's previous behavior so existing deployments upgrade untouched. It's no longer *hardcoded* — set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` to use the OTel default (`:4318`). fastecho sets this default only when the var is unset, so operators keep full control. (Same reasoning as the metrics-exporter default: override an SDK default to preserve existing behavior, but stay overridable.)
+- **Outbound client wraps, doesn't replace.** `telemetry.WrapClient`/ `WrapTransport` decorate a normal `*http.Client`/`RoundTripper` with `traceparent` injection and `X-Request-Id` forwarding — no factory, options, or typed verbs. The caller keeps full control of timeout, redirects, and headers; fastecho only adds the propagation that's specific to it.
+- **Logs stay on zap.** Correlation comes from structured fields, not a log exporter — your platform already ships stdout.
 
 ---
 
@@ -143,30 +86,19 @@ Three IDs travel with every request:
 | `span_id`    | Identifies one operation within the trace                 | The active span                                                        |
 | `request_id` | A fastecho-level request identifier (UUIDv4)              | The request-id middleware, or forwarded from an inbound `X-Request-Id` |
 
-They are built in **one place** — `fctx.Fields(ctx)` — so middleware, the panic
-recover handler, the access log, and background workers all derive them
-identically. `Fields` reads `trace_id`/`span_id` from the active span context and
-`request_id` from the request context, and returns them as structured log fields.
+They are built in **one place** — `fctx.Fields(ctx)` — so middleware, the panic recover handler, the access log, and background workers all derive them identically. `Fields` reads `trace_id`/`span_id` from the active span context and `request_id` from the request context, and returns them as structured log fields.
 
-Discrete fields (not the raw `traceparent` header) let the log backend **query
-by `trace_id`** and link a line to its trace.
+Discrete fields (not the raw `traceparent` header) let the log backend **query by `trace_id`** and link a line to its trace.
 
-On the trace side, the request id also rides along as a span attribute
-(`fastecho.request_id`), so you can find a trace from a request id and vice versa.
+On the trace side, the request id also rides along as a span attribute (`fastecho.request_id`), so you can find a trace from a request id and vice versa.
 
 ---
 
 ## Traces
 
-A **trace** is a tree of **spans**. Each span is a timed operation with a name,
-start/end, attributes, and a parent. The root span for an HTTP request is created
-by **`otelecho`**, the upstream Echo instrumentation — fastecho no longer
-hand-rolls this.
+A **trace** is a tree of **spans**. Each span is a timed operation with a name, start/end, attributes, and a parent. The root span for an HTTP request is created by **`otelecho`**, the upstream Echo instrumentation — fastecho no longer hand-rolls this.
 
-**Server spans.** `otelecho` starts a span per request and records it on **stable
-semantic conventions** (semconv): `http.request.method`, `http.route`,
-`http.response.status_code`, `url.path`, etc. These names are an ecosystem
-standard, so any OTel-aware backend or dashboard understands them out of the box.
+**Server spans.** `otelecho` starts a span per request and records it on **stable semantic conventions** (semconv): `http.request.method`, `http.route`, `http.response.status_code`, `url.path`, etc. These names are an ecosystem standard, so any OTel-aware backend or dashboard understands them out of the box.
 
 **Spans in your own code.** Inside a handler or service, use the helpers:
 
@@ -175,24 +107,14 @@ ctx, span := telemetry.StartSpan(ctx) // auto-named after the calling function
 defer span.End()
 ```
 
-`StartSpan` resolves the tracer from `ctx` (`fctx.Tracer(ctx)`), so it uses
-whichever provider the request is running under — and falls back to a no-op
-tracer (zero spans, no panic) if tracing is off.
+`StartSpan` resolves the tracer from `ctx` (`fctx.Tracer(ctx)`), so it uses whichever provider the request is running under — and falls back to a no-op tracer (zero spans, no panic) if tracing is off.
 
-**Propagation.** Trace context crosses service hops via the W3C `traceparent`
-propagator, registered globally:
+**Propagation.** Trace context crosses service hops via the W3C `traceparent` propagator, registered globally:
 
 - **Inbound:** `otelecho` extracts `traceparent` and continues the upstream trace.
-- **Outbound:** `telemetry.WrapClient` injects `traceparent` (and forwards
-  `X-Request-Id`) onto every request — see [Outbound calls](#outbound-calls).
+- **Outbound:** `telemetry.WrapClient` injects `traceparent` (and forwards `X-Request-Id`) onto every request — see [Outbound calls](#outbound-calls).
 
-**Sampling.** How many traces are kept is **env-driven**, read directly by the
-OTel SDK from `OTEL_TRACES_SAMPLER` / `OTEL_TRACES_SAMPLER_ARG`. fastecho does
-*not* hand-roll a sampler — the SDK already handles every standard value
-(`always_on`, `always_off`, ratio-based, and the `parentbased_*` variants) and
-defaults to `parentbased_always_on` (keep everything, respecting the caller's
-decision). "ParentBased" means: if an incoming request was already sampled
-upstream, honor that; only the root of a new trace consults the ratio.
+**Sampling.** How many traces are kept is **env-driven**, read directly by the OTel SDK from `OTEL_TRACES_SAMPLER` / `OTEL_TRACES_SAMPLER_ARG`. fastecho does *not* hand-roll a sampler — the SDK already handles every standard value (`always_on`, `always_off`, ratio-based, and the `parentbased_*` variants) and defaults to `parentbased_always_on` (keep everything, respecting the caller's decision). "ParentBased" means: if an incoming request was already sampled upstream, honor that; only the root of a new trace consults the ratio.
 
 ---
 
@@ -200,55 +122,30 @@ upstream, honor that; only the root of a new trace consults the ratio.
 
 A **metric** is an aggregate number over time. fastecho produces four families:
 
-1. **HTTP server metrics** (from `otelecho`) — request duration histograms and
-   counts, on stable semconv names like
-   `http_server_request_duration_seconds_*` (labelled by route pattern —
-   `http_route` — so the series stay bounded).
-2. **Go runtime metrics** (`go.*`) — GC, goroutines, memory, from the OTel
-   runtime instrumentation.
-3. **Worker failures** — `fastecho.worker.failures{worker,kind}` (`kind` =
-   `panic`|`error`), a framework counter for background-worker failures. Workers
-   aren't on the auto-traced HTTP path, so this is what makes them *alertable*:
-   `rate(fastecho_worker_failures_total{worker="…"}[5m]) > 0`. Normal/cancelled
-   shutdowns don't count.
-4. **Whatever you record** — `telemetry.Init` registers the meter provider as the
-   OTel **global**, so record custom metrics with plain OTel via `otel.Meter(...)`
-   (see the [OpenTelemetry Go metrics docs](https://opentelemetry.io/docs/languages/go/instrumentation/#metrics)).
-   Pass the request `ctx` to `Add`/`Record` so measurements pick up exemplars, and
-   keep attribute values low-cardinality (high-cardinality detail belongs on the
-   span, not the metric).
+1. **HTTP server metrics** (from `otelecho`) — request duration histograms and counts, on stable semconv names like `http_server_request_duration_seconds_*` (labelled by route pattern — `http_route` — so the series stay bounded).
+2. **Go runtime metrics** (`go.*`) — GC, goroutines, memory, from the OTel runtime instrumentation.
+3. **Worker failures** — `fastecho.worker.failures{worker,kind}` (`kind` = `panic`|`error`), a framework counter for background-worker failures. Workers aren't on the auto-traced HTTP path, so this is what makes them *alertable*: `rate(fastecho_worker_failures_total{worker="…"}[5m]) > 0`. Normal/cancelled shutdowns don't count.
+4. **Whatever you record** — `telemetry.Init` registers the meter provider as the OTel **global**, so record custom metrics with plain OTel via `otel.Meter(...)` (see the [OpenTelemetry Go metrics docs](https://opentelemetry.io/docs/languages/go/instrumentation/#metrics)). Pass the request `ctx` to `Add`/`Record` so measurements pick up exemplars, and keep attribute values low-cardinality (high-cardinality detail belongs on the span, not the metric).
 
 ### The `/metrics` endpoint
 
-By default fastecho serves metrics at **`/metrics` on the service's main port**,
-in Prometheus format, for a Prometheus server to scrape. (More on that delivery
-model in [Pull vs push](#pull-vs-push).) The metric names changed from the old
-`echo_http_*` to the semconv `http_server_request_duration_seconds_*` — see the
-README's Breaking changes section.
+By default fastecho serves metrics at **`/metrics` on the service's main port**, in Prometheus format, for a Prometheus server to scrape. (More on that delivery model in [Pull vs push](#pull-vs-push).) The metric names changed from the old `echo_http_*` to the semconv `http_server_request_duration_seconds_*` — see the README's Breaking changes section.
 
 ---
 
 ## Logs
 
-Logs **stay on zap** — structured JSON on stdout. There is intentionally **no
-OTLP log bridge**: shipping logs is your platform's job (stdout → your log
-pipeline), and `fctx.Logger(ctx)` remains a plain `*zap.Logger`.
+Logs **stay on zap** — structured JSON on stdout. There is intentionally **no OTLP log bridge**: shipping logs is your platform's job (stdout → your log pipeline), and `fctx.Logger(ctx)` remains a plain `*zap.Logger`.
 
-Logs now **carry the correlation fields** (`trace_id`/`span_id`/`request_id`) via
-`fctx.Fields`, so a log line links to its trace without any log exporter. The
-access log, the panic recover handler, and worker logs all use the same
-enrichment.
+Logs now **carry the correlation fields** (`trace_id`/`span_id`/`request_id`) via `fctx.Fields`, so a log line links to its trace without any log exporter. The access log, the panic recover handler, and worker logs all use the same enrichment.
 
-The access log logs 3xx/4xx/5xx responses (2xx stays quiet) and keeps the error
-string on 5xx lines, so a failing request leaves both a log entry *and* an error
-on its span.
+The access log logs 3xx/4xx/5xx responses (2xx stays quiet) and keeps the error string on 5xx lines, so a failing request leaves both a log entry *and* an error on its span.
 
 ---
 
 ## Pull vs push
 
-**Delivery model (pull/push) and wire transport (gRPC/HTTP) are two different
-axes.**
+**Delivery model (pull/push) and wire transport (gRPC/HTTP) are two different axes.**
 
 **Metrics** can be delivered either way:
 
@@ -260,10 +157,7 @@ axes.**
 | Short-lived jobs | Weak (may exit before scrape)        | Strong (push before exit)                        |
 | Set via          | `OTEL_METRICS_EXPORTER=prometheus`   | `OTEL_METRICS_EXPORTER=otlp`                     |
 
-fastecho **defaults to pull**: its services are long-lived HTTP servers with
-stable network identity (ideal scrape targets), pull gives a free up/down signal,
-and the framework only has to expose a registry. Push suits short-lived jobs or a
-single unified OTLP pipeline.
+fastecho **defaults to pull**: its services are long-lived HTTP servers with stable network identity (ideal scrape targets), pull gives a free up/down signal, and the framework only has to expose a registry. Push suits short-lived jobs or a single unified OTLP pipeline.
 
 **Traces are always push** — there's no pull model for spans:
 
@@ -272,15 +166,9 @@ single unified OTLP pipeline.
 | Metrics | Yes (a counter/gauge value) | Small, bounded | Pull works |
 | Traces  | No (completed *events*)     | High, bursty   | Push only  |
 
-A metric is a value that exists *now* and can be read on demand. A span is a past
-*event* — by the time you'd pull it, it's already over and would have to be
-buffered waiting for you. Spans are also a firehose. So every tracing protocol
-(OTLP, Jaeger, Zipkin) is push; there is no `/metrics`-equivalent for spans.
+A metric is a value that exists *now* and can be read on demand. A span is a past *event* — by the time you'd pull it, it's already over and would have to be buffered waiting for you. Spans are also a firehose. So every tracing protocol (OTLP, Jaeger, Zipkin) is push; there is no `/metrics`-equivalent for spans.
 
-> In the **default** config, fastecho runs two delivery models at once: traces
-> **push** (OTLP), metrics **pull** (scrape). Setting `OTEL_METRICS_EXPORTER=otlp`
-> unifies them onto one OTLP push pipeline — simpler to operate (one endpoint,
-> one collector) at the cost of the free scrape-based liveness signal.
+> In the **default** config, fastecho runs two delivery models at once: traces **push** (OTLP), metrics **pull** (scrape). Setting `OTEL_METRICS_EXPORTER=otlp` unifies them onto one OTLP push pipeline — simpler to operate (one endpoint, one collector) at the cost of the free scrape-based liveness signal.
 
 ---
 
@@ -288,37 +176,25 @@ buffered waiting for you. Spans are also a firehose. So every tracing protocol
 
 Exemplars link an aggregated metric back to an individual trace.
 
-Metrics are aggregates, and aggregation throws away individual identity. A
-histogram bucket says:
+Metrics are aggregates, and aggregation throws away individual identity. A histogram bucket says:
 
 ```
 http_server_request_duration_seconds_bucket{le="0.25"} 47
 ```
 
-"47 requests finished under 250ms" — but not *which* 47. When p99 latency spikes,
-the metric shows something is slow, not which request, leaving you to search
-traces by time range.
+"47 requests finished under 250ms" — but not *which* 47. When p99 latency spikes, the metric shows something is slow, not which request, leaving you to search traces by time range.
 
-**An exemplar** is a concrete example measurement attached to a metric bucket,
-carrying the `trace_id` of a request that landed there:
+**An exemplar** is a concrete example measurement attached to a metric bucket, carrying the `trace_id` of a request that landed there:
 
 ```
 http_server_request_duration_seconds_bucket{le="0.25"} 47 # {trace_id="4bf92f...",span_id="00f0..."} 0.237 1700000000
 ```
 
-That trailing part is one specific request that took 0.237s, and the exact trace
-you can open. In Grafana these render as **clickable dots** on the latency graph:
-click the dot on the p99 spike to jump to *that* trace's waterfall in Tempo/Jaeger.
+That trailing part is one specific request that took 0.237s, and the exact trace you can open. In Grafana these render as **clickable dots** on the latency graph: click the dot on the p99 spike to jump to *that* trace's waterfall in Tempo/Jaeger.
 
-**Why it's tied to sampling** (`OTEL_METRICS_EXEMPLAR_FILTER=trace_based`, the
-default): an exemplar is only recorded when the measurement happened inside a
-**sampled** span context. Its entire value is the `trace_id` it points at — if
-that trace wasn't kept, the link would dangle. `trace_based` means "only attach
-exemplars whose trace actually got stored."
+**Why it's tied to sampling** (`OTEL_METRICS_EXEMPLAR_FILTER=trace_based`, the default): an exemplar is only recorded when the measurement happened inside a **sampled** span context. Its entire value is the `trace_id` it points at — if that trace wasn't kept, the link would dangle. `trace_based` means "only attach exemplars whose trace actually got stored."
 
-**Visibility is a backend concern.** fastecho records exemplars at the SDK. To
-see and click them, the backend must be wired up: Prometheus with exemplar
-storage enabled, and a trace backend (Tempo) for Grafana to jump into.
+**Visibility is a backend concern.** fastecho records exemplars at the SDK. To see and click them, the backend must be wired up: Prometheus with exemplar storage enabled, and a trace backend (Tempo) for Grafana to jump into.
 
 ---
 
@@ -339,28 +215,17 @@ storage enabled, and a trace backend (Tempo) for Grafana to jump into.
                         └─ exemplars link Prometheus panels → Tempo traces
 ```
 
-- **Prometheus** scrapes `/metrics` and stores the time series; you build
-  dashboards and alerts on `http_server_request_duration_seconds_*`, `go.*`, etc.
-- **The Collector** receives pushed traces (and optionally pushed metrics if you
-  flip to OTLP) and forwards them to **Tempo** (or Jaeger).
-- **Grafana** reads both, and — with exemplar storage + a Tempo data source — lets
-  you click an exemplar on a metrics panel straight through to the trace.
+- **Prometheus** scrapes `/metrics` and stores the time series; you build dashboards and alerts on `http_server_request_duration_seconds_*`, `go.*`, etc.
+- **The Collector** receives pushed traces (and optionally pushed metrics if you flip to OTLP) and forwards them to **Tempo** (or Jaeger).
+- **Grafana** reads both, and — with exemplar storage + a Tempo data source — lets you click an exemplar on a metrics panel straight through to the trace.
 
-The correlation IDs make the manual pivots work too: a `trace_id` in a log line
-pastes into Tempo; a `fastecho.request_id` span attribute matches the
-`request_id` in your logs.
+The correlation IDs make the manual pivots work too: a `trace_id` in a log line pastes into Tempo; a `fastecho.request_id` span attribute matches the `request_id` in your logs.
 
 ---
 
 ## Deploying behind an OTel Collector
 
-In production you almost never point fastecho straight at a backend. The
-recommended topology is **app SDK → a local OpenTelemetry Collector → backend**.
-The collector owns batching, retry, and back-pressure (the SDK deliberately
-doesn't), and it's where org-wide resource attributes get injected. **The
-app→collector hop and the collector→backend hop are independent** — the collector
-can receive plain HTTP from your app and forward gRPC+TLS to the backend, so the
-backend wanting gRPC never forces gRPC on your app.
+In production you almost never point fastecho straight at a backend. The recommended topology is **app SDK → a local OpenTelemetry Collector → backend**. The collector owns batching, retry, and back-pressure (the SDK deliberately doesn't), and it's where org-wide resource attributes get injected. **The app→collector hop and the collector→backend hop are independent** — the collector can receive plain HTTP from your app and forward gRPC+TLS to the backend, so the backend wanting gRPC never forces gRPC on your app.
 
 The three signals reach the collector by **three different paths**:
 
@@ -371,99 +236,51 @@ The three signals reach the collector by **three different paths**:
     │  stdout   ──tailed by a filelog receiver───────────▶  collector ─▶ backend
 ```
 
-**Traces — push OTLP to the collector.** Point `OTEL_EXPORTER_OTLP_ENDPOINT` at
-the collector. fastecho defaults the protocol to gRPC (`:4317`); for an
-HTTP/protobuf receiver (`:4318`) set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`.
+**Traces — push OTLP to the collector.** Point `OTEL_EXPORTER_OTLP_ENDPOINT` at the collector. fastecho defaults the protocol to gRPC (`:4317`); for an HTTP/protobuf receiver (`:4318`) set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`.
 
 **Metrics — pick *one* path, not both:**
 
-- **Scrape (default):** keep `OTEL_METRICS_EXPORTER=prometheus` and let a
-  collector's `prometheus` receiver scrape `/metrics`. Annotate the pod
-  (`prometheus.io/scrape: "true"`, `prometheus.io/port`, `prometheus.io/path: "/metrics"`).
-  Zero exporter config; the metric *names* are the semconv ones.
-- **Push:** set `OTEL_METRICS_EXPORTER=otlp` and metrics push over the same OTLP
-  endpoint. This carries **exemplars natively** (the cleanest path for
-  metric→trace links). If you switch to push, **remove the scrape annotation** so
-  the collector doesn't also scrape and double-count.
+- **Scrape (default):** keep `OTEL_METRICS_EXPORTER=prometheus` and let a collector's `prometheus` receiver scrape `/metrics`. Annotate the pod (`prometheus.io/scrape: "true"`, `prometheus.io/port`, `prometheus.io/path: "/metrics"`). Zero exporter config; the metric *names* are the semconv ones.
+- **Push:** set `OTEL_METRICS_EXPORTER=otlp` and metrics push over the same OTLP endpoint. This carries **exemplars natively** (the cleanest path for metric→trace links). If you switch to push, **remove the scrape annotation** so the collector doesn't also scrape and double-count.
 
-**Logs — nothing to configure.** A node/DaemonSet collector with a `filelog`
-receiver tails every pod's stdout and forwards it. fastecho writes JSON to
-stdout, so it's picked up automatically — no OTLP log exporter. Two app-side
-details make the logs *useful* once they land:
+**Logs — nothing to configure.** A node/DaemonSet collector with a `filelog` receiver tails every pod's stdout and forwards it. fastecho writes JSON to stdout, so it's picked up automatically — no OTLP log exporter. Two app-side details make the logs *useful* once they land:
 
-- **Lowercase `level`.** fastecho emits `"level":"info"` so the collector can map
-  it to a log-level label and the UI can color-code by severity. (Uppercase
-  `INFO` is often not recognised by that mapping.)
-- **`trace_id` / `span_id` fields.** A collector's trace parser reads exactly
-  these JSON keys to attach trace context to each log line — which is what makes
-  a log line link to its trace in the UI. fastecho emits them via `fctx.Fields`.
+- **Lowercase `level`.** fastecho emits `"level":"info"` so the collector can map it to a log-level label and the UI can color-code by severity. (Uppercase `INFO` is often not recognised by that mapping.)
+- **`trace_id` / `span_id` fields.** A collector's trace parser reads exactly these JSON keys to attach trace context to each log line — which is what makes a log line link to its trace in the UI. fastecho emits them via `fctx.Fields`.
 
-**Mandatory resource attributes.** Many platforms require certain resource
-attributes (team, system, environment) and *silently drop* data without them.
-Inject them at the collector (a `resource` processor) or set them on the app via
-`OTEL_RESOURCE_ATTRIBUTES` / `OTEL_SERVICE_NAME` — wherever your org standard
-lives. The collector path is convenient because it applies them uniformly.
+**Mandatory resource attributes.** Many platforms require certain resource attributes (team, system, environment) and *silently drop* data without them. Inject them at the collector (a `resource` processor) or set them on the app via `OTEL_RESOURCE_ATTRIBUTES` / `OTEL_SERVICE_NAME` — wherever your org standard lives. The collector path is convenient because it applies them uniformly.
 
-> **With the Grafana stack**, the three signals land in **Mimir** (metrics),
-> **Loki** (logs), and **Tempo** (traces), fed by the Collector above: metrics
-> scraped from `/metrics` (keep the default exporter + a `prometheus.io/scrape`
-> annotation), logs tailed from stdout into Loki, and traces pushed to the
-> Collector (gRPC `:4317` by default).
+> **With the Grafana stack**, the three signals land in **Mimir** (metrics), **Loki** (logs), and **Tempo** (traces), fed by the Collector above: metrics scraped from `/metrics` (keep the default exporter + a `prometheus.io/scrape` annotation), logs tailed from stdout into Loki, and traces pushed to the Collector (gRPC `:4317` by default).
 
 ---
 
 ## Outbound calls
 
-When your service calls another service, the trace should continue across the
-hop. Wrap your HTTP client:
+When your service calls another service, the trace should continue across the hop. Wrap your HTTP client:
 
 ```go
 client := telemetry.WrapClient(&http.Client{Timeout: 5 * time.Second})
 ```
 
-`WrapClient` augments the client's transport so every request **injects
-`traceparent`** (via `otelhttp`, continuing the current trace) and **forwards
-`fctx.RequestID(ctx)` as `X-Request-Id`**. You keep a completely normal
-`*http.Client` — your timeout, redirect policy, and headers are yours; fastecho
-only decorates the transport. (`WrapTransport(base)` does the same for a bare
-`RoundTripper`, e.g. a generated client.)
+`WrapClient` augments the client's transport so every request **injects `traceparent`** (via `otelhttp`, continuing the current trace) and **forwards `fctx.RequestID(ctx)` as `X-Request-Id`**. You keep a completely normal `*http.Client` — your timeout, redirect policy, and headers are yours; fastecho only decorates the transport. (`WrapTransport(base)` does the same for a bare `RoundTripper`, e.g. a generated client.)
 
-The result: a downstream service running this same stack continues *your* trace
-and logs *your* request id — one unbroken story across services.
+The result: a downstream service running this same stack continues *your* trace and logs *your* request id — one unbroken story across services.
 
 ---
 
 ## Under the hood
 
-- **OpenTelemetry SDK** is the engine. fastecho's `telemetry` package is a thin
-  bootstrap over it.
-- **`telemetry.Init`** builds one **resource** (shared identity for every
-  signal), the tracer and meter providers, env-driven exporters, and a single
-  `Shutdown` closer that drains traces and metrics together. It always returns
-  non-nil providers — when a signal is disabled it installs a **no-op** provider,
-  so nothing downstream has to nil-check.
-- **Exporters are chosen by environment**, via the OTel `autoexport` helper
-  (`OTEL_TRACES_EXPORTER`, `OTEL_METRICS_EXPORTER`). The same binary is configured
-  per deployment; fastecho adds only two `OTEL_*` defaults beyond the SDK's own,
-  both to preserve prior behavior and both overridable: metrics to `prometheus`
-  (so `/metrics` keeps serving on the main port) and OTLP transport to `grpc`.
-- **Service identity** comes from `OTEL_SERVICE_NAME` (+ `OTEL_RESOURCE_ATTRIBUTES`);
-  a `service.instance.id` is generated if you don't set one.
-- **Startup log line.** On boot, fastecho emits one structured `info` line —
-  `telemetry configured` — with the resolved exporters, OTLP protocol/endpoint,
-  and the metrics delivery model. It's a structured log rather than an ASCII
-  banner so it's queryable/alertable in your log backend (and readable in the dev
-  console), making an upgrade or misconfiguration visible immediately instead of
-  failing silently.
+- **OpenTelemetry SDK** is the engine. fastecho's `telemetry` package is a thin bootstrap over it.
+- **`telemetry.Init`** builds one **resource** (shared identity for every signal), the tracer and meter providers, env-driven exporters, and a single `Shutdown` closer that drains traces and metrics together. It always returns non-nil providers — when a signal is disabled it installs a **no-op** provider, so nothing downstream has to nil-check.
+- **Exporters are chosen by environment**, via the OTel `autoexport` helper (`OTEL_TRACES_EXPORTER`, `OTEL_METRICS_EXPORTER`). The same binary is configured per deployment; fastecho adds only two `OTEL_*` defaults beyond the SDK's own, both to preserve prior behavior and both overridable: metrics to `prometheus` (so `/metrics` keeps serving on the main port) and OTLP transport to `grpc`.
+- **Service identity** comes from `OTEL_SERVICE_NAME` (+ `OTEL_RESOURCE_ATTRIBUTES`); a `service.instance.id` is generated if you don't set one.
+- **Startup log line.** On boot, fastecho emits one structured `info` line — `telemetry configured` — with the resolved exporters, OTLP protocol/endpoint, and the metrics delivery model. It's a structured log rather than an ASCII banner so it's queryable/alertable in your log backend (and readable in the dev console), making an upgrade or misconfiguration visible immediately instead of failing silently.
 
 ### Configuration
 
 The control surface is two layers:
 
-- **`OTEL_*` environment variables** — *behaviour* values (which exporter, which
-  endpoint, sampling ratio), read by the OTel SDK. One source of truth per
-  setting; nothing is mirrored as a Go struct field.
-- **`fastecho.Opts`** — on/off *toggles* only: `Opts.Tracing.Skip`,
-  `Opts.Metrics.Skip`, `Opts.Logs.Skip`.
+- **`OTEL_*` environment variables** — *behaviour* values (which exporter, which endpoint, sampling ratio), read by the OTel SDK. One source of truth per setting; nothing is mirrored as a Go struct field.
+- **`fastecho.Opts`** — on/off *toggles* only: `Opts.Tracing.Skip`, `Opts.Metrics.Skip`, `Opts.Logs.Skip`.
 
 See the README's Observability section for the full env-var and toggle tables.

--- a/fastecho.go
+++ b/fastecho.go
@@ -377,15 +377,14 @@ func (s *server) run(host string, port string) error {
 
 // serve starts the HTTP server and shuts it down gracefully once ctx is done.
 func (s *server) serve(ctx context.Context, host string, port string) error {
-	// Defer the shutdown of the telemetry providers
 	defer func() { _ = s.Providers.Shutdown(context.Background()) }()
 
 	// Flush buffered logs on the way out
 	defer func() { _ = s.Logger.Sync() }()
 
-	// One counter for all workers; labelled per worker/kind at record time.
-	// MeterProvider is always non-nil (noop when metrics are skipped → Add is a
-	// no-op), so this is safe to create unconditionally.
+	// One counter for all workers, labelled per worker/kind at record time.
+	// MeterProvider is always non-nil (noop when metrics are skipped), so this is
+	// safe to create unconditionally.
 	s.workerFailures, _ = s.Providers.MeterProvider.Meter(telemetry.ScopeName).Int64Counter(
 		"fastecho.worker.failures",
 		metric.WithDescription("background worker panics and error exits"),

--- a/fctx/fields.go
+++ b/fctx/fields.go
@@ -23,11 +23,10 @@ import (
 )
 
 // Fields returns the correlation fields for ctx: trace_id and span_id (when a
-// valid span context is present) and request_id (when set). It is the one place
-// these IDs are built, so middleware, the recover handler, and worker seeds all
-// derive them the same way.
-//
-// These are discrete, indexable log fields (not the traceparent wire header) so the log backend can query by trace_id and link a line to its trace.
+// valid span context is present) and request_id (when set). Centralising them
+// here keeps middleware, the recover handler, and worker seeds consistent.
+// They are discrete, indexable log fields (not the traceparent wire header) so
+// the log backend can query by trace_id and link a line to its trace.
 func Fields(ctx context.Context) []zap.Field {
 	var fields []zap.Field
 

--- a/router/router.go
+++ b/router/router.go
@@ -106,21 +106,18 @@ func AddRoute(r *Router, group *echo.Group, path string, handlerFunc echo.Handle
 	return r
 }
 
-// addMetrics serves the OTel Prometheus exporter's registry at /metrics on the
-// main port - but only when a gatherer is provided, i.e. OTEL_METRICS_EXPORTER=
-// prometheus. Under OTLP push (or none) the gatherer is nil and /metrics is NOT
-// mounted: app metrics push via OTLP and never reach a prometheus registry, so the
-// only thing the default registry holds is client_golang's go/process collectors -
-// serving those at /metrics would advertise the wrong pipeline (and invite a
-// double-scrape). No endpoint is clearer than a misleading one.
+// addMetrics serves the OTel Prometheus exporter's registry at /metrics, but only
+// when a gatherer is provided (OTEL_METRICS_EXPORTER=prometheus). Under OTLP push
+// the gatherer is nil and /metrics is not mounted: the default registry would only
+// hold go/process collectors, so serving it would advertise the wrong pipeline.
+// No endpoint is clearer than a misleading one.
 func (r *Router) addMetrics(e *echo.Echo, gatherer prometheus.Gatherer) *Router {
 	if gatherer == nil {
-		return r // push / none: no /metrics endpoint
+		return r
 	}
 	// EnableOpenMetrics so exemplars (the trace_id/span_id the OTel exporter attaches
-	// to counters and histograms) survive exposition - the classic Prometheus text
-	// format has no syntax for them, so without this they're silently dropped here.
-	// Content-negotiated: a scraper that doesn't Accept OpenMetrics still gets plain text.
+	// to metrics) survive exposition; the classic Prometheus text format can't encode
+	// them. Content-negotiated, so a non-OpenMetrics scraper still gets plain text.
 	e.GET("/metrics", echo.WrapHandler(promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{
 		EnableOpenMetrics: true,
 	})))

--- a/telemetry/httpclient.go
+++ b/telemetry/httpclient.go
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// httpclient.go adds outbound HTTP propagation to the telemetry package: it
-// decorates an existing *http.Client / RoundTripper so a request carries its
-// inbound correlation onward - W3C traceparent (via otelhttp) and the
-// X-Request-Id from fctx - keeping a distributed trace unbroken across a service
-// hop instead of starting fresh on every outbound call. (Package doc lives in
-// telemetry.go.)
+// httpclient.go decorates an *http.Client / RoundTripper so outbound requests
+// propagate their inbound correlation - W3C traceparent (via otelhttp) and the
+// fctx X-Request-Id - keeping a distributed trace unbroken across service hops.
+// (Package doc lives in telemetry.go.)
 package telemetry
 
 import (
@@ -28,11 +26,9 @@ import (
 	"github.com/ingka-group/fastecho/fctx"
 )
 
-// WrapClient augments c's transport so every request it sends propagates the
-// caller's trace context (traceparent, via otelhttp) and forwards
-// fctx.RequestID(ctx) as X-Request-Id. It mutates and returns c; a nil or
-// zero-value client is fine. Set the timeout, headers, etc. on c as usual -
-// this only decorates the transport.
+// WrapClient decorates c's transport so every request propagates the caller's
+// trace context (via otelhttp) and forwards fctx.RequestID as X-Request-Id. It
+// mutates and returns c; a nil client is allocated. Only the transport changes.
 func WrapClient(c *http.Client) *http.Client {
 	if c == nil {
 		c = &http.Client{}

--- a/telemetry/span.go
+++ b/telemetry/span.go
@@ -29,33 +29,18 @@ import (
 // ScopeName is the instrumentation scope name for fastecho's own spans.
 const ScopeName = "github.com/ingka-group/fastecho/"
 
-// StartSpan starts a child span named after the calling function and returns
-// the updated context and span. End the span with defer span.End().
-//
-// The span name is auto-discovered from the caller using runtime.Caller,
-// formatted as package.Type.Method (e.g. "forecast.Service.Recompute").
-//
-// Uses the tracer from fctx.Tracer(ctx); falls back to a no-op tracer if none is set.
-//
-// For custom span names, use the standard OTel API directly:
-//
-//	tracer := otel.Tracer("my-scope")
-//	ctx, span := tracer.Start(ctx, "custom-name")
+// StartSpan starts a child span named after the calling function (formatted as
+// package.Type.Method, e.g. "forecast.Service.Recompute") and returns the updated
+// context and span; end it with defer span.End(). It uses the tracer from
+// fctx.Tracer(ctx), falling back to a no-op. For a custom name, call the OTel
+// tracer API directly.
 func StartSpan(ctx context.Context, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
 	return fctx.Tracer(ctx).Start(ctx, callerName(1), opts...)
 }
 
-// SpanFunc wraps a function call in a span with the given name. The span starts
-// before fn is called and ends after fn returns. Use this for tracing functions
-// that don't accept context.Context:
-//
-//	var result T
-//	telemetry.SpanFunc(ctx, "heavy-algorithm", func() {
-//	    result = computeHeavyAlgorithm(data)
-//	})
-//
-// If fn panics, the panic is recorded on the span and re-raised.
-// If tracing is not configured, fn is still called (no-op span).
+// SpanFunc runs fn inside a span named name, for tracing work that has no
+// context.Context to thread. A panic in fn is recorded on the span and re-raised.
+// With tracing off, fn still runs under a no-op span.
 func SpanFunc(ctx context.Context, name string, fn func()) {
 	_, span := fctx.Tracer(ctx).Start(ctx, name)
 	defer span.End()
@@ -78,13 +63,12 @@ func callerName(skip int) string {
 	}
 	name := runtime.FuncForPC(pc).Name()
 
-	// Strip module path: "github.com/ingka-group/myservice/internal/forecast.(*Service).Recompute"
-	// becomes "forecast.(*Service).Recompute"
+	// Strip the module path, leaving package.Type.Method.
 	if idx := strings.LastIndex(name, "/"); idx >= 0 {
 		name = name[idx+1:]
 	}
 
-	// Strip pointer receiver: "forecast.(*Service).Recompute" becomes "forecast.Service.Recompute"
+	// Strip pointer-receiver punctuation: "(*Service)" -> "Service".
 	name = strings.ReplaceAll(name, "(*", "")
 	name = strings.ReplaceAll(name, ")", "")
 

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// telemetry.go is the OpenTelemetry bootstrap half of the package (span.go has
-// StartSpan/SpanFunc + ScopeName). It builds one resource, env-driven exporters
-// and sampling, and one shutdown closer shared by traces and metrics, so the two
-// signals share identity and drain together.
+// telemetry.go bootstraps OpenTelemetry: one shared resource, env-driven
+// exporters and sampling, and one shutdown closer so traces and metrics share
+// identity and drain together. (StartSpan/SpanFunc live in span.go.)
 package telemetry
 
 import (
@@ -41,26 +40,22 @@ import (
 	tracenoop "go.opentelemetry.io/otel/trace/noop"
 )
 
-// (ScopeName lives in span.go, the same package, so it is not redeclared here.)
-
-// Config carries only wiring that has no env equivalent. Behaviour values
-// (exporter endpoint, sampling, which exporter) come from OTEL_* env so there
-// is one source of truth per setting; a struct field would duplicate that.
+// Config carries only wiring that has no env equivalent; behaviour values
+// (endpoint, sampling, exporter) come from OTEL_* env so there is one source of
+// truth per setting.
 type Config struct {
 	// SetGlobal registers the providers + propagator as the process-global OTel
-	// singletons. Run/Initialize always pass true (otelecho/otelhttp read the
-	// global propagator to carry traceparent across hops); tests pass false so
-	// parallel instances don't clobber the global. Not exposed on fastecho.Config:
-	// disabling it in production would silently break propagation.
+	// singletons (otelecho/otelhttp read the global propagator to carry
+	// traceparent across hops). Tests pass false so parallel instances don't
+	// clobber the global; not exposed on fastecho.Config because disabling it in
+	// production would silently break propagation.
 	SetGlobal bool
 	// SkipTraces / SkipMetrics disable a signal entirely.
 	SkipTraces  bool
 	SkipMetrics bool
 }
 
-// Providers holds the configured providers and a single shutdown closer. It is a
-// pure runtime handle: the startup snapshot is returned separately from Init as an
-// Info, not parked on the handle it has nothing to do with at runtime.
+// Providers holds the configured providers and a single shutdown closer.
 type Providers struct {
 	TracerProvider trace.TracerProvider
 	MeterProvider  metric.MeterProvider
@@ -70,15 +65,14 @@ type Providers struct {
 	shutdown           func(context.Context) error
 }
 
-// Info is what Init resolved from OTEL_* env and the cfg toggles, for the caller to
-// log once at startup (see fastecho config()). Init owns the env defaults, so it
-// hands the resolution back rather than make the caller re-derive it.
+// Info is what Init resolved from OTEL_* env and the cfg toggles, for the caller
+// to log once at startup.
 type Info struct {
 	ServiceName     string
 	Traces          bool   // exporter active (not SkipTraces)
 	TracesExporter  string // OTEL_TRACES_EXPORTER (default "otlp")
-	OTLPProtocol    string // resolved transport (signal-specific var → general → "http/protobuf"); the fastecho server path forces "grpc" before Init (config()), so it reports "grpc" there but "http/protobuf" on a bare Init
-	OTLPEndpoint    string // OTEL_EXPORTER_OTLP_ENDPOINT; "" => SDK default (grpc localhost:4317, http/protobuf localhost:4318/v1/<signal>)
+	OTLPProtocol    string // resolved transport: signal-specific var → general → "http/protobuf"
+	OTLPEndpoint    string // OTEL_EXPORTER_OTLP_ENDPOINT; "" => SDK default
 	Metrics         bool
 	MetricsExporter string // OTEL_METRICS_EXPORTER (default "prometheus")
 	MetricsDelivery string // "pull (/metrics)" | "push" | "off"
@@ -213,7 +207,7 @@ func Init(ctx context.Context, cfg Config) (*Providers, Info, error) {
 // metricsExporter returns the configured metrics exporter, defaulting to
 // prometheus so /metrics stays on the main port (the OTel SDK default is otlp).
 func metricsExporter() string {
-	return envOr("OTEL_METRICS_EXPORTER", "prometheus") // envOr added in L3
+	return envOr("OTEL_METRICS_EXPORTER", "prometheus")
 }
 
 func envOr(key, def string) string {
@@ -223,11 +217,10 @@ func envOr(key, def string) string {
 	return def
 }
 
-// otlpProtocol resolves the OTLP transport exactly the way autoexport does
-// (spans.go/metrics.go): the signal-specific var wins, then the general
-// OTEL_EXPORTER_OTLP_PROTOCOL, then the SDK default "http/protobuf". Reading only
-// the general var would misreport (and mis-default) the moment an operator sets
-// the signal-specific one - so Info would name a transport the exporter isn't using.
+// otlpProtocol resolves the OTLP transport the way autoexport does: the
+// signal-specific var wins, then OTEL_EXPORTER_OTLP_PROTOCOL, then "http/protobuf".
+// Reading only the general var would misreport once an operator sets the
+// signal-specific one.
 func otlpProtocol(signalKey string) string {
 	if v := os.Getenv(signalKey); v != "" {
 		return v
@@ -235,11 +228,9 @@ func otlpProtocol(signalKey string) string {
 	return envOr("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
 }
 
-// newResource builds the shared resource: service.name/version from env,
-// service.instance.id generated if unset.
+// newResource builds the shared resource from env, generating a
+// service.instance.id only when the operator hasn't set one.
 func newResource(ctx context.Context) (*resource.Resource, error) {
-	// The operator's service.instance.id (via OTEL_RESOURCE_ATTRIBUTES) wins;
-	// generate one only when unset.
 	opts := []resource.Option{resource.WithFromEnv()}
 	if !envHasServiceInstanceID() {
 		opts = append(opts, resource.WithAttributes(

--- a/worker.go
+++ b/worker.go
@@ -78,11 +78,9 @@ func (s *server) runWorker(ctx context.Context, name string, w Worker) {
 // error so that one worker cannot crash the process or affect the others.
 func (s *server) runWorkerOnce(ctx context.Context, name string, w Worker) {
 	ctx = fctx.WithLogger(ctx, s.Logger.With(zap.String("worker", name)))
-	// Seed a tracer that stamps worker=<name> on every span it starts, so the
-	// worker's spans are filterable by worker - they're roots (no inbound HTTP
-	// request), so this label is how you find all runs of a given worker. (This
-	// is exactly what the ctx-scoped tracer buys us: a per-context tracer the
-	// global can't express.) Providers is always non-nil; noop tracer when skipped.
+	// Seed a tracer that stamps worker=<name> on every span; worker spans are
+	// roots (no inbound request), so this label is how you find all runs of a
+	// worker. Providers is always non-nil (noop tracer when tracing is skipped).
 	ctx = fctx.WithTracer(ctx, workerTracer{
 		Tracer: s.Providers.TracerProvider.Tracer(telemetry.ScopeName),
 		attrs:  []attribute.KeyValue{attribute.String("worker", name)},
@@ -108,11 +106,9 @@ func (s *server) runWorkerOnce(ctx context.Context, name string, w Worker) {
 }
 
 // recordWorkerFailure increments the worker-failure counter, labelled by worker
-// and kind (panic|error), so failures are alertable per worker, e.g.
-// rate(fastecho_worker_failures_total{worker="..."}[5m]) > 0. Only fastecho can
-// see these (they happen in runWorkerOnce), so it's a framework-owned metric -
-// like otelecho's HTTP metrics, not a consumer helper. Nil-safe: the counter is
-// created on the Run path (serve); direct runWorkerOnce unit tests may leave it unset.
+// and kind (panic|error), so failures are alertable per worker. Nil-safe: the
+// counter is created on the serve path, so direct runWorkerOnce unit tests may
+// leave it unset.
 func (s *server) recordWorkerFailure(ctx context.Context, name, kind string) {
 	if s.workerFailures == nil {
 		return
@@ -123,12 +119,10 @@ func (s *server) recordWorkerFailure(ctx context.Context, name, kind string) {
 	))
 }
 
-// workerTracer wraps a tracer so every span it starts carries the worker's name
-// as an attribute. Worker spans have no inbound-request parent, so labelling them
-// is how you find all runs of one worker in the trace backend. Note: we do NOT
-// span the whole worker run - workers are long-lived (block until shutdown), so a
-// run-spanning span would stay open for the service lifetime and never export.
-// The worker body spans each unit of work; this tracer just labels those spans.
+// workerTracer stamps the worker's name on every span it starts. We deliberately
+// do not span the whole run: workers block until shutdown, so a run-spanning span
+// would stay open for the service lifetime and never export. The worker body
+// spans each unit of work; this tracer just labels those spans.
 type workerTracer struct {
 	trace.Tracer
 	attrs []attribute.KeyValue


### PR DESCRIPTION
## Docs — README observability section for the OTel-only release

Stacked on `otel/telemetry-client` (base of this PR). Final PR in the stack.

This PR commits **only `README.md`**:
- New **Observability (OpenTelemetry)** section: every honored `OTEL_*` env knob (with fastecho's defaults distinguished from SDK defaults), the `Opts.*.Skip` code toggles, and links to the OTel libraries in use.
- A **Breaking changes** subsection: metric/attribute renames (`echo_http_*` → `http_server_request_duration_seconds_*`, semconv labels), lowercase log levels, the `Config.Workers` map migration, the `otel`→`telemetry` package rename, removal of the hand-rolled trace middleware, and the `/metrics` backward-compat note (unset `OTEL_METRICS_EXPORTER` still defaults to `prometheus` pull — no action needed).
- Updated examples: `telemetry.StartSpan`/`SpanFunc`, `telemetry.WrapClient`, map-form `Workers`.

> The conceptual guides `docs/observability.md` and `docs/observability-dos-and-donts.md` are authored alongside this work but committed separately by the maintainer.

### Verification
- `make pre-commit` green. Docs cross-checked against the shipped env/API/metric names. README → docs link resolves.
